### PR TITLE
Fix: fingerprint-injector docs no longer specifies destructing fingerprint

### DIFF
--- a/docs/guides/fingerprint-injector.md
+++ b/docs/guides/fingerprint-injector.md
@@ -41,7 +41,7 @@ const { FingerprintInjector }  = require('fingerprint-injector');
         browsers: [{ name: 'firefox', minVersion: 88 }],
     });
 
-    const { fingerprint } = fingerprintGenerator.getFingerprint();
+    const browserFingerprintWithHeaders = fingerprintGenerator.getFingerprint();
 
     const fingerprintInjector = new FingerprintInjector();
 
@@ -53,7 +53,7 @@ const { FingerprintInjector }  = require('fingerprint-injector');
         locale: fingerprint.navigator.language,
     });
    // Attach fingerprint
-   await fingerprintInjector.attachFingerprintToPlaywright(context, fingerprint);
+   await fingerprintInjector.attachFingerprintToPlaywright(context, browserFingerprintWithHeaders);
 
    const page = await context.newPage();
 })();
@@ -76,11 +76,11 @@ const puppeteer = require('puppeteer')
         browsers: [{ name: 'chrome', minVersion: 88 }],
     });
 
-    const { fingerprint } = fingerprintGenerator.getFingerprint();
+    const browserFingerprintWithHeaders = fingerprintGenerator.getFingerprint();
     const browser = await puppeteer.launch({headless: false})
     const page = await browser.newPage();
     // Attach fingerprint to page
-    await fingerprintInjector.attachFingerprintToPuppeteer(page, fingerprint);
+    await fingerprintInjector.attachFingerprintToPuppeteer(page, browserFingerprintWithHeaders);
     // Now you can use the page
     await page.goto('https://google.com')
 


### PR DESCRIPTION
Context
---

[Fingerprint Injector documentation](https://apify.github.io/fingerprint-suite/docs/guides/fingerprint-injector/#usage-with-the-puppeteer) specifies destructuring `fingerprint` from the `getFingerPrint` response:

```js
const { fingerprint } = fingerprintGenerator.getFingerprint();
```

`fingerprintGenerator.getFingerprint();` returns type:

```js
type BrowserFingerprintWithHeaders = {
    headers: Headers;
    fingerprint: Fingerprint;
};
```

Issue
---

This instruction conflicts with FingerprintInjector#attachFingerprintTo types

```js
attachFingerprintToPlaywright(browserContext: BrowserContext, browserFingerprintWithHeaders: BrowserFingerprintWithHeaders): Promise<void>;
attachFingerprintToPuppeteer(page: Page, browserFingerprintWithHeaders: BrowserFingerprintWithHeaders): Promise<void>;
```

This results in an error:

```bash
Argument of type 'Fingerprint' is not assignable to parameter of type 'BrowserFingerprintWithHeaders'.
  Type 'Fingerprint' is missing the following properties from type 'BrowserFingerprintWithHeaders': headers, fingerprint

await fingerprintInjector.attachFingerprintToPuppeteer(page, fingerprint);
```

Solution
---

Docs now instruct the passing of the entire `fingerprintGenerator.getFingerprint()` response for both `fingerprintInjector.attachFingerprintToPuppeteer` and `fingerprintInjector.attachFingerprintToPuppeteer`.