### PR TITLE
feat: injection helpers

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,8 +37,8 @@ With the help of `fingerprint-suite` you can generate and inject browser fingerp
 The following example shows how to use the fingerprinting tools to camouflage your Playwright-managed Chromium instance.
 
 ```typescript
-const { chromium } = require('playwright');
-const { newInjectedContext }  = require('fingerprint-injector');
+import { chromium } from 'playwright';
+import { newInjectedContext } from 'fingerprint-injector';
 
 (async () => {
     const browser = await chromium.launch({ headless: false });
@@ -68,8 +68,8 @@ const { newInjectedContext }  = require('fingerprint-injector');
 Here is the same example using Puppeteer:
 
 ```typescript
-const puppeteer = require('puppeteer');
-const { newInjectedPage }  = require('fingerprint-injector');
+import puppeteer from 'puppeteer';
+import { newInjectedPage } from 'fingerprint-injector';
 
 (async () => {
     const browser = await puppeteer.launch({ headless: false });

--- a/README.md
+++ b/README.md
@@ -38,34 +38,54 @@ The following example shows how to use the fingerprinting tools to camouflage yo
 
 ```typescript
 const { chromium } = require('playwright');
-const { FingerprintGenerator } = require('fingerprint-generator');
-const { FingerprintInjector }  = require('fingerprint-injector');
+const { newInjectedContext }  = require('fingerprint-injector');
 
 (async () => {
-    const fingerprintGenerator = new FingerprintGenerator();
-
-    const browserFingerprintWithHeaders = fingerprintGenerator.getFingerprint({
-        devices: ['desktop'],
-        browsers: ['chrome'],
-    });
-
-    const fingerprintInjector = new FingerprintInjector();
-    const { fingerprint } = browserFingerprintWithHeaders;
-
     const browser = await chromium.launch({ headless: false });
+    const context = await newInjectedContext(
+        browser,
+        {
+            // Constraints for the generated fingerprint (optional)
+            fingerprintOptions: {
+                devices: ['mobile'],
+                operatingSystems: ['ios'],
+            },
+            // Playwright's newContext() options (optional, random example for illustration)
+            newContextOptions: {
+                geolocation: {
+                    latitude: 51.50853,
+                    longitude: -0.12574,
+                }
+            }
+        },
+    );
 
-    // With certain properties, we need to inject the props into the context initialization
-    const context = await browser.newContext({
-        userAgent: fingerprint.userAgent,
-        locale: fingerprint.navigator.language,
-        viewport: fingerprint.screen,
-    });
-   
-    // Attach the rest of the fingerprint
-   await fingerprintInjector.attachFingerprintToPlaywright(context, browserFingerprintWithHeaders);
-
-   const page = await context.newPage();
+    const page = await context.newPage();
    // ... your code using `page` here
+})();
+```
+
+Here is the same example using Puppeteer:
+
+```typescript
+const puppeteer = require('puppeteer');
+const { newInjectedPage }  = require('fingerprint-injector');
+
+(async () => {
+    const browser = await puppeteer.launch({ headless: false });
+    const page = await newInjectedPage(
+        browser,
+        {
+            // constraints for the generated fingerprint
+            fingerprintOptions: {
+                devices: ['mobile'],
+                operatingSystems: ['ios'],
+            },
+        },
+    );
+
+    // ... your code using `page` here
+    await page.goto('https://example.com');
 })();
 ```
 

--- a/packages/fingerprint-injector/src/fingerprint-injector.ts
+++ b/packages/fingerprint-injector/src/fingerprint-injector.ts
@@ -232,33 +232,33 @@ export class FingerprintInjector {
  * @param browser Playwright Browser instance.
  * @param options.fingerprintOptions Options for the underlying FingerprintGenerator instance.
  * @param options.newContextOptions Options for the new context creation.
- *  > Note: The `userAgent`, `viewport` and some HTTP headers will be overwritten with the values from the generated fingerprint.
+ *  > Note: Setting `userAgent` or `viewport` in `newContextOptions` will override the values from the generated fingerprint.
  * @returns BrowserContext with injected fingerprint.
  */
 export async function newInjectedContext(
     browser: PWBrowser,
-    options? : Partial<{
-        fingerprintOptions: Partial<FingerprintGeneratorOptions>;
-        newContextOptions: BrowserContextOptions;
-    }>,
+    options? : {
+        fingerprintOptions?: Partial<FingerprintGeneratorOptions>;
+        newContextOptions?: BrowserContextOptions;
+    },
 ): Promise<BrowserContext> {
     const generator = new FingerprintGenerator();
     const fingerprintWithHeaders = generator.getFingerprint(options?.fingerprintOptions ?? {});
 
     const { fingerprint, headers } = fingerprintWithHeaders;
     const context = await browser.newContext({
-        ...options?.newContextOptions,
         userAgent: fingerprint.navigator.userAgent,
+        colorScheme: 'dark',
+        ...options?.newContextOptions,
         viewport: {
-            ...options?.newContextOptions?.viewport,
             width: fingerprint.screen.width,
             height: fingerprint.screen.height,
+            ...options?.newContextOptions?.viewport,
         },
         extraHTTPHeaders: {
-            ...options?.newContextOptions?.extraHTTPHeaders,
             'accept-language': headers['accept-language'],
+            ...options?.newContextOptions?.extraHTTPHeaders,
         },
-        colorScheme: 'dark',
     });
 
     const injector = new FingerprintInjector();
@@ -269,9 +269,9 @@ export async function newInjectedContext(
 
 export async function newInjectedPage(
     browser: PPBrowser,
-    options? : Partial<{
-        fingerprintOptions: Partial<FingerprintGeneratorOptions>;
-    }>,
+    options? : {
+        fingerprintOptions?: Partial<FingerprintGeneratorOptions>;
+    },
 ): Promise<Page> {
     const generator = new FingerprintGenerator();
     const fingerprintWithHeaders = generator.getFingerprint(options?.fingerprintOptions ?? {});

--- a/scripts/publish.sh
+++ b/scripts/publish.sh
@@ -9,8 +9,6 @@ for FOLDER in $SCRIPT_DIR/../packages/*; do
     if [[ " ${PACKAGES_TO_PUBLISH[@]} " =~ " ${PACKAGE_NAME} " ]]; then
       echo "Publishing $PACKAGE_NAME"
       cd $FOLDER/dist
-
-      npm owner add jindrich.bar
       npm publish
 
       cd $SCRIPT_DIR/../


### PR DESCRIPTION
Some (if not most) users don't perform the browser injection correctly - for example, in Playwright, the userAgent and screen dimensions have to be passed into the `newContext` method in order to have all the holes patched. 

The "minimal" example in README is also long and not very comprehensive because of this. This PR adds two helper functions for Playwright (`newInjectedContext`) and Puppeteer (`newInjectedPage`) which handle all the complicated injection details inside. 