### PR TITLE
feat: overwrite WebRTC APIs with a recursive ES6 proxy

### DIFF
--- a/packages/fingerprint-generator/src/fingerprint-generator.ts
+++ b/packages/fingerprint-generator/src/fingerprint-generator.ts
@@ -51,8 +51,6 @@ export type VideoCard = {
     vendor: string;
 }
 
-type WebRTC = 'enabled' | 'disabled';
-
 export type Fingerprint = {
     screen: ScreenFingerprint;
     navigator: NavigatorFingerprint;
@@ -63,7 +61,7 @@ export type Fingerprint = {
     videoCard: VideoCard;
     multimediaDevices: string[];
     fonts: string[];
-    webrtc: WebRTC;
+    mockWebRTC: boolean;
 }
 
 export type BrowserFingerprintWithHeaders = {
@@ -82,7 +80,7 @@ export interface FingerprintGeneratorOptions extends HeaderGeneratorOptions {
         minHeight?: number;
         maxHeight?: number;
     };
-    webrtc?: WebRTC;
+    mockWebRTC?: boolean;
 }
 
 /**
@@ -99,7 +97,7 @@ export class FingerprintGenerator extends HeaderGenerator {
         super(options);
         this.fingerprintGlobalOptions = {
             screen: options.screen,
-            webrtc: options.webrtc,
+            mockWebRTC: options.mockWebRTC,
         };
         this.fingerprintGeneratorNetwork = new BayesianNetwork({ path: `${__dirname}/data_files/fingerprint-network-definition.zip` });
     }
@@ -181,7 +179,7 @@ export class FingerprintGenerator extends HeaderGenerator {
             return {
                 fingerprint: {
                     ...this.transformFingerprint(fingerprint),
-                    webrtc: options.webrtc ?? this.fingerprintGlobalOptions.webrtc ?? 'enabled',
+                    mockWebRTC: options.mockWebRTC ?? this.fingerprintGlobalOptions.mockWebRTC ?? false,
                 },
                 headers,
             };

--- a/packages/fingerprint-generator/src/fingerprint-generator.ts
+++ b/packages/fingerprint-generator/src/fingerprint-generator.ts
@@ -51,6 +51,8 @@ export type VideoCard = {
     vendor: string;
 }
 
+type WebRTC = 'enabled' | 'disabled';
+
 export type Fingerprint = {
     screen: ScreenFingerprint;
     navigator: NavigatorFingerprint;
@@ -61,6 +63,7 @@ export type Fingerprint = {
     videoCard: VideoCard;
     multimediaDevices: string[];
     fonts: string[];
+    webrtc: WebRTC;
 }
 
 export type BrowserFingerprintWithHeaders = {
@@ -79,6 +82,7 @@ export interface FingerprintGeneratorOptions extends HeaderGeneratorOptions {
         minHeight?: number;
         maxHeight?: number;
     };
+    webrtc?: WebRTC;
 }
 
 /**
@@ -95,6 +99,7 @@ export class FingerprintGenerator extends HeaderGenerator {
         super(options);
         this.fingerprintGlobalOptions = {
             screen: options.screen,
+            webrtc: options.webrtc,
         };
         this.fingerprintGeneratorNetwork = new BayesianNetwork({ path: `${__dirname}/data_files/fingerprint-network-definition.zip` });
     }
@@ -174,7 +179,10 @@ export class FingerprintGenerator extends HeaderGenerator {
             fingerprint.languages = acceptedLanguages;
 
             return {
-                fingerprint: this.transformFingerprint(fingerprint),
+                fingerprint: {
+                    ...this.transformFingerprint(fingerprint),
+                    webrtc: options.webrtc ?? this.fingerprintGlobalOptions.webrtc ?? 'enabled',
+                },
                 headers,
             };
         }

--- a/packages/fingerprint-injector/src/fingerprint-injector.ts
+++ b/packages/fingerprint-injector/src/fingerprint-injector.ts
@@ -18,6 +18,7 @@ declare function overrideWebGl(webGlInfo: Record<string, string>) : void;
 declare function overrideIntlAPI(language: string) : void;
 declare function overrideStatic() : void;
 declare function runHeadlessFixes() : void;
+declare function blockWebRTC() : void;
 
 /**
  * Fingerprint injector class.
@@ -197,6 +198,8 @@ export class FingerprintInjector {
             };
 
             runHeadlessFixes();
+
+            blockWebRTC();
 
             overrideIntlAPI(navigatorProps.language);
             overrideStatic();

--- a/packages/fingerprint-injector/src/fingerprint-injector.ts
+++ b/packages/fingerprint-injector/src/fingerprint-injector.ts
@@ -158,7 +158,7 @@ export class FingerprintInjector {
                 historyLength,
                 audioCodecs,
                 videoCodecs,
-                webrtc,
+                mockWebRTC,
                 // @ts-expect-error internal browser code
             } = fp as EnhancedFingerprint;
 
@@ -200,9 +200,7 @@ export class FingerprintInjector {
 
             runHeadlessFixes();
 
-            if (webrtc === 'disabled') {
-                blockWebRTC();
-            }
+            if (mockWebRTC) blockWebRTC();
 
             overrideIntlAPI(navigatorProps.language);
             overrideStatic();

--- a/packages/fingerprint-injector/src/fingerprint-injector.ts
+++ b/packages/fingerprint-injector/src/fingerprint-injector.ts
@@ -158,6 +158,7 @@ export class FingerprintInjector {
                 historyLength,
                 audioCodecs,
                 videoCodecs,
+                webrtc,
                 // @ts-expect-error internal browser code
             } = fp as EnhancedFingerprint;
 
@@ -199,7 +200,9 @@ export class FingerprintInjector {
 
             runHeadlessFixes();
 
-            blockWebRTC();
+            if (webrtc === 'disabled') {
+                blockWebRTC();
+            }
 
             overrideIntlAPI(navigatorProps.language);
             overrideStatic();

--- a/packages/fingerprint-injector/src/utils.js
+++ b/packages/fingerprint-injector/src/utils.js
@@ -451,6 +451,32 @@ function overrideDocumentDimensionsProps(props) {
     }
 }
 
+// Replaces all the WebRTC related methods with a recursive ES6 Proxy 
+// This way, we don't have to model a mock WebRTC API and we still don't get any exceptions.
+function blockWebRTC() {
+    const handler = {
+        get: () => {
+            return new Proxy(() => {}, handler);
+        },
+        apply: () => {
+            return new Proxy(() => {}, handler);
+        },
+        construct: () => {
+            return new Proxy(() => {}, handler);
+        },
+    };
+    
+    const ConstrProxy = new Proxy(Object, handler);
+
+    navigator.mediaDevices.getUserMedia =
+    navigator.webkitGetUserMedia =
+    navigator.mozGetUserMedia =
+    navigator.getUserMedia =
+    window.webkitRTCPeerConnection = new Proxy(() => {}, handler);
+    MediaStreamTrack =
+    RTCPeerConnection = ConstrProxy;
+}
+
 // eslint-disable-next-line no-unused-vars
 function overrideUserAgentData(userAgentData) {
     try {


### PR DESCRIPTION
While this solution is a bit crude, it seems to work in 100% of all cases. 

From what I found, it doesn't even trigger scripts inspecting properties of Web API objects (but it also might be that WebRTC API is a bit too obscure for those scripts to even check). 

fixes #124 