### PR TITLE
feat: properly override browser HTTP headers

### DIFF
--- a/packages/fingerprint-injector/src/fingerprint-injector.ts
+++ b/packages/fingerprint-injector/src/fingerprint-injector.ts
@@ -41,10 +41,7 @@ export class FingerprintInjector {
             enhancedFingerprint,
         );
 
-        // Override the language properly
-        await browserContext.setExtraHTTPHeaders({
-            'accept-language': headers['accept-language'],
-        });
+        await browserContext.setExtraHTTPHeaders(headers);
 
         await browserContext.on('page', (page) => {
             page.emulateMedia({ colorScheme: 'dark' })
@@ -79,10 +76,7 @@ export class FingerprintInjector {
             deviceScaleFactor: screen.devicePixelRatio,
 
         });
-        // Override the language properly
-        await page.setExtraHTTPHeaders({
-            'accept-language': headers['accept-language'],
-        });
+        await page.setExtraHTTPHeaders(headers);
 
         await page.emulateMediaFeatures([
             { name: 'prefers-color-scheme', value: 'dark' },

--- a/test/fingerprint-injector/fingerprint-injector.test.ts
+++ b/test/fingerprint-injector/fingerprint-injector.test.ts
@@ -35,7 +35,7 @@ const cases = [
                 options: {
                     args: [
                         '--no-sandbox',
-                        '--use-gl=egl',
+                        '--use-gl=desktop',
                     ],
                     channel: 'chrome',
                 },
@@ -49,7 +49,7 @@ const cases = [
                 options: {
                     args: [
                         '--no-sandbox',
-                        '--use-gl=egl',
+                        '--use-gl=desktop',
                     ],
                 },
                 fingerprintGeneratorOptions: {
@@ -250,6 +250,14 @@ describe('FingerprintInjector', () => {
                         return [null, null];
                     }
                 });
+
+                if (!browserVendor || !browserRenderer) {
+                    // this can happen with headless browsers / systems without hardware graphical accelerators - e.g. CI
+                    expect(browserVendor).toBeNull();
+                    expect(browserRenderer).toBeNull();
+
+                    return;
+                }
 
                 expect(browserVendor).toBe(vendor);
                 expect(browserRenderer).toBe(renderer);


### PR DESCRIPTION
Now properly overrides headers in Playwright / Puppeteer - managed browsers.

Minor fixes for WebGL tests in Puppeteer introduced.

fixes apify/crawlee#1825