### PR TITLE
feat: provide a raw fingerprint to the helper

### DIFF
--- a/packages/fingerprint-injector/src/fingerprint-injector.ts
+++ b/packages/fingerprint-injector/src/fingerprint-injector.ts
@@ -271,12 +271,13 @@ export class FingerprintInjector {
 export async function newInjectedContext(
     browser: PWBrowser,
     options? : {
+        fingerprint?: BrowserFingerprintWithHeaders;
         fingerprintOptions?: Partial<FingerprintGeneratorOptions>;
         newContextOptions?: BrowserContextOptions;
     },
 ): Promise<BrowserContext> {
     const generator = new FingerprintGenerator();
-    const fingerprintWithHeaders = generator.getFingerprint(options?.fingerprintOptions ?? {});
+    const fingerprintWithHeaders = options?.fingerprint ?? generator.getFingerprint(options?.fingerprintOptions ?? {});
 
     const { fingerprint, headers } = fingerprintWithHeaders;
     const context = await browser.newContext({
@@ -303,11 +304,12 @@ export async function newInjectedContext(
 export async function newInjectedPage(
     browser: PPBrowser,
     options? : {
+        fingerprint?: BrowserFingerprintWithHeaders;
         fingerprintOptions?: Partial<FingerprintGeneratorOptions>;
     },
 ): Promise<Page> {
     const generator = new FingerprintGenerator();
-    const fingerprintWithHeaders = generator.getFingerprint(options?.fingerprintOptions ?? {});
+    const fingerprintWithHeaders = options?.fingerprint ?? generator.getFingerprint(options?.fingerprintOptions ?? {});
 
     const page = await browser.newPage();
 


### PR DESCRIPTION
Adds a new `fingerprint` option to the `newInjectedContext` / `newInjectedPage` helpers. When provided, the helper injects the provided fingerprint (does not generate a new one every time).

Useful if you want to reuse the same fingerprint multiple times across browser contexts / page instances. 