### PR TITLE
chore: update GitHub workflow secrets

### DIFF
--- a/.github/workflows/e2e-benchmark.yml
+++ b/.github/workflows/e2e-benchmark.yml
@@ -14,7 +14,7 @@ jobs:
     steps:
       - uses: actions/checkout@v3
         with:
-          token: ${{ secrets.GH_TOKEN }}
+          token: ${{ secrets.APIFY_SERVICE_ACCOUNT_GITHUB_TOKEN }}
       - name: Use Node.js 16
         uses: actions/setup-node@v3
         with:

--- a/.github/workflows/model-updater.yml
+++ b/.github/workflows/model-updater.yml
@@ -62,7 +62,7 @@ jobs:
           npm run prerelease
           npm run buildNetwork
         env:
-          APIFY_DATASET_URL: ${{ secrets.APIFY_DATASET_URL }}
+          APIFY_FINGERPRINT_DATASET_ID: ${{ secrets.APIFY_FINGERPRINT_DATASET_ID }}
 
       - name: Get the new version number
         id: get_version

--- a/.github/workflows/model-updater.yml
+++ b/.github/workflows/model-updater.yml
@@ -16,7 +16,7 @@ jobs:
       # Runs a single command using the runners shell
       - uses: actions/checkout@v3
         with:
-          token: ${{ secrets.GH_TOKEN }}
+          token: ${{ secrets.APIFY_SERVICE_ACCOUNT_GITHUB_TOKEN }}
       - name: Use Node.js 16
         uses: actions/setup-node@v3
         with:
@@ -84,7 +84,7 @@ jobs:
       - name: Create release
         uses: actions/create-release@v1
         env:
-          GITHUB_TOKEN: ${{ secrets.GH_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.APIFY_SERVICE_ACCOUNT_GITHUB_TOKEN }}
         with:
           tag_name: ${{ steps.get_version.outputs.version }}
           release_name: ${{ steps.get_version.outputs.version }}

--- a/.github/workflows/release-publish.yml
+++ b/.github/workflows/release-publish.yml
@@ -15,7 +15,7 @@ jobs:
             -   name: Checkout Source code
                 uses: actions/checkout@v3
                 with:
-                    token: ${{ secrets.GH_TOKEN }}
+                    token: ${{ secrets.APIFY_SERVICE_ACCOUNT_GITHUB_TOKEN }}
 
             -   name: Use Node.js 16
                 uses: actions/setup-node@v3
@@ -47,9 +47,9 @@ jobs:
                     export GIT_TAG=$(echo $GITHUB_REF | sed 's/refs\/tags\///g')
                     npm run release 
                 env:
-                    NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
-                    GIT_USER: "noreply@apify.com:${{ secrets.GH_TOKEN }}"
-                    GH_TOKEN: ${{ secrets.GH_TOKEN }}
+                    NPM_TOKEN: ${{ secrets.APIFY_SERVICE_ACCOUNT_NPM_TOKEN }}
+                    GIT_USER: "noreply@apify.com:${{ secrets.APIFY_SERVICE_ACCOUNT_GITHUB_TOKEN }}"
+                    GH_TOKEN: ${{ secrets.APIFY_SERVICE_ACCOUNT_GITHUB_TOKEN }}
 
             - name: Commit the version bump
               uses: stefanzweifel/git-auto-commit-action@v4

--- a/scripts/netgen.sh
+++ b/scripts/netgen.sh
@@ -6,7 +6,7 @@ echo "Downloading data..."
 
 curl \
     -o $(dirname $0)/dataset.json \
-    "$APIFY_DATASET_URL";
+    "https://api.apify.com/v2/datasets/${APIFY_FINGERPRINT_DATASET_ID}/items?clean=true&format=json&desc=true&limit=30000";
 
 echo "Generating network..."
 


### PR DESCRIPTION
This updates the workflow secrets to the organization-level ones, which are synced from Doppler.