### PR TITLE
fix: filter generated connection: 'close' headers

### DIFF
--- a/packages/header-generator/src/header-generator.ts
+++ b/packages/header-generator/src/header-generator.ts
@@ -285,6 +285,7 @@ export class HeaderGenerator {
         }
 
         for (const attribute of Object.keys(generatedSample)) {
+            if (attribute.toLowerCase() === 'connection' && generatedSample[attribute] === 'close') delete generatedSample[attribute];
             if (attribute.startsWith('*') || generatedSample[attribute] === MISSING_VALUE_DATASET_TOKEN) delete generatedSample[attribute];
         }
 


### PR DESCRIPTION
Some HTTP clients cannot set the `connection: close` header since it interferes with their internal HTTP implementation. In other cases, setting this header might decrease browser performance, as closing the HTTP connection after each request is an (HTTP 1.0) antipattern. This PR removes `connection: close` headers from the generated samples. 

Closes apify/got-scraping#70