### PR TITLE
feat: add the slim mode for disabling performance-heavy evasions

### DIFF
--- a/packages/fingerprint-generator/src/fingerprint-generator.ts
+++ b/packages/fingerprint-generator/src/fingerprint-generator.ts
@@ -63,6 +63,7 @@ export type Fingerprint = {
     multimediaDevices: string[];
     fonts: string[];
     mockWebRTC: boolean;
+    slim?: boolean;
 }
 
 export type BrowserFingerprintWithHeaders = {
@@ -82,6 +83,13 @@ export interface FingerprintGeneratorOptions extends HeaderGeneratorOptions {
         maxHeight?: number;
     };
     mockWebRTC?: boolean;
+    /**
+     * Enables the slim mode for the fingerprint injection.
+     * This disables some performance-heavy evasions, but might decrease benchmark scores.
+     *
+     * Try enabling this if you are experiencing performance issues with the fingerprint injection.
+     */
+    slim?: boolean;
 }
 
 /**
@@ -99,6 +107,7 @@ export class FingerprintGenerator extends HeaderGenerator {
         this.fingerprintGlobalOptions = {
             screen: options.screen,
             mockWebRTC: options.mockWebRTC,
+            slim: options.slim,
         };
         this.fingerprintGeneratorNetwork = new BayesianNetwork({ path: `${__dirname}/data_files/fingerprint-network-definition.zip` });
     }
@@ -181,6 +190,7 @@ export class FingerprintGenerator extends HeaderGenerator {
                 fingerprint: {
                     ...this.transformFingerprint(fingerprint),
                     mockWebRTC: options.mockWebRTC ?? this.fingerprintGlobalOptions.mockWebRTC ?? false,
+                    slim: options.slim ?? this.fingerprintGlobalOptions.slim ?? false,
                 },
                 headers,
             };

--- a/packages/fingerprint-injector/src/fingerprint-injector.ts
+++ b/packages/fingerprint-injector/src/fingerprint-injector.ts
@@ -160,6 +160,7 @@ export class FingerprintInjector {
                 audioCodecs,
                 videoCodecs,
                 mockWebRTC,
+                slim,
                 // @ts-expect-error internal browser code
             } = fp as EnhancedFingerprint;
 
@@ -202,6 +203,12 @@ export class FingerprintInjector {
             runHeadlessFixes();
 
             if (mockWebRTC) blockWebRTC();
+
+            if (slim) {
+                // @ts-expect-error internal browser code
+                // eslint-disable-next-line dot-notation
+                window['slim'] = true;
+            }
 
             overrideIntlAPI(navigatorProps.language);
             overrideStatic();

--- a/packages/fingerprint-injector/src/utils.js
+++ b/packages/fingerprint-injector/src/utils.js
@@ -4,7 +4,7 @@ const isFirefox = navigator.userAgent.includes("Firefox");
 const isSafari = navigator.userAgent.includes("Safari") && !navigator.userAgent.includes("Chrome");
 
 let slim = null;
-function getslim() {
+function getSlim() {
     if(slim === null) {
         slim = window.slim || false;
         if(typeof window.slim !== 'undefined') {
@@ -120,7 +120,7 @@ function overrideInstancePrototype(instance, overrideObj) {
  * @param {*} originalObj 
  */
 function redirectToString(proxyObj, originalObj) {
-    if(getslim()) return;
+    if(getSlim()) return;
 
     const handler = {
         setPrototypeOf: (target, newProto) => {


### PR DESCRIPTION
The browser injected with a custom fingerprint hangs for too long on some pages - this is because some of the evasions replace parts of the Web API with less performant mocks. 

If the given page relies too much on those Web API parts (calls them too often), this can cause quite serious performance issues. By enabling the new `slim` option, you can disable some of the evasions - with the potential danger of standing out a bit more to the antibot services.