### PR TITLE
docs: simplify link

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@
 Today's websites are increasingly using fingerprinting to track users and identify them.
 With the help of `fingerprint-suite` you can generate and inject browser fingerprints into your browser, allowing you to fly your scrapers under the radar.
 
-> Would you like to work with us on our fingerprinting tools or similar projects? [We are hiring!](https://apify.com/jobs#senior-node.js-engineer)
+> Would you like to work with us on our fingerprinting tools or similar projects? [We are hiring!](https://apify.com/jobs)
 
 ## Overview
 


### PR DESCRIPTION
Seems like this anchor doesn't exist anymore. Linking the careers page should be enough?