### PR TITLE
Validate input data before training the models

### DIFF
--- a/packages/generative-bayesian-network/src/bayesian-network.ts
+++ b/packages/generative-bayesian-network/src/bayesian-network.ts
@@ -88,6 +88,7 @@ export class BayesianNetwork {
      * @param dataframe A Danfo.js dataframe containing the data.
      */
     setProbabilitiesAccordingToData(data: RecordList) {
+        const validatedData = data.filter(validateRecord);
         this.nodesInSamplingOrder.forEach((node, i) => {
             // eslint-disable-next-line no-console
             console.log(`${i}/${this.nodesInSamplingOrder.length} Setting probabilities for node ${node.name}`);
@@ -95,7 +96,7 @@ export class BayesianNetwork {
             for (const parentName of node.parentNames) {
                 possibleParentValues[parentName] = this.nodesByName[parentName].possibleValues;
             }
-            node.setProbabilitiesAccordingToData(data, possibleParentValues);
+            node.setProbabilitiesAccordingToData(validatedData, possibleParentValues);
         });
     }
 
@@ -114,4 +115,18 @@ export class BayesianNetwork {
         zip.addFile('network.json', Buffer.from(JSON.stringify(network), 'utf8'));
         zip.writeZip(path);
     }
+}
+
+function validateRecord(record: Record<string, any>): boolean {
+    const { browserFingerprint } = record;
+    if (!browserFingerprint) return false;
+
+    const { navigator } = browserFingerprint;
+    if (!navigator) return false;
+
+    if (navigator.appCodeName !== 'Mozilla') return false;
+
+    if (typeof navigator.userAgent !== 'string' || navigator.userAgent.trim() === '') return false;
+
+    return true;
 }

--- a/packages/generator-networks-creator/src/generator-networks-creator.ts
+++ b/packages/generator-networks-creator/src/generator-networks-creator.ts
@@ -25,6 +25,20 @@ const PLUGIN_CHARACTERISTICS_ATTRIBUTES = [
     'mimeTypes',
 ];
 
+function validateRecord(record: Record<string, any>): boolean {
+    const { browserFingerprint } = record;
+    if (!browserFingerprint) return false;
+
+    const { navigator } = browserFingerprint;
+    if (!navigator) return false;
+
+    if (navigator.appCodeName !== 'Mozilla') return false;
+
+    if (typeof navigator.userAgent !== 'string' || navigator.userAgent.trim() === '') return false;
+
+    return true;
+}
+
 async function prepareRecords(records: Record<string, any>[], preprocessingType: string) : Promise<Record<string, any>[]> {
     const cleanedRecords = records
         .filter((
@@ -42,7 +56,8 @@ async function prepareRecords(records: Record<string, any>[], preprocessingType:
                 },
             }) => ((width >= 1280 && width > height) || (width < height && /phone|android|mobile/i.test(userAgent))),
         )
-        .map((record) => ({ ...record, userAgent: record.browserFingerprint.userAgent } as any));
+        .map((record) => ({ ...record, userAgent: record.browserFingerprint.userAgent } as any))
+        .filter(validateRecord);
 
     // TODO this could break if the list is not there anymore
     // The robots list is available under the MIT license, for details see https://github.com/atmire/COUNTER-Robots/blob/master/LICENSE

--- a/test/generative-bayesian-network/generation.test.ts
+++ b/test/generative-bayesian-network/generation.test.ts
@@ -65,4 +65,30 @@ describe('Generation tests', () => {
             }
         }
     });
+
+    test('Only processes validated data', () => {
+        const rows : string[][] = [];
+
+        await new Promise<void>((res) => {
+            parseFile(path.join(__dirname, './testDataset.csv'))
+            .on('data', r => rows.push(r))
+            .on('end', () => {
+               res();
+            })
+        });
+
+        const data = rows.slice(1).map(r => {
+            const x = {} as Record<string, any>;
+            for(let i = 0; i < r.length; i++) {
+                x[rows[0][i]] = r[i];
+            }
+            return x;
+        });
+
+        const invalidData = [...data, { browserFingerprint: { navigator: { appCodeName: 'NotMozilla', userAgent: '' } } }];
+        
+        testGeneratorNetwork.setProbabilitiesAccordingToData(invalidData);
+        testGeneratorNetwork.saveNetworkDefinition({path: testNetworkDefinitionPath});
+        expect(testGeneratorNetwork.generateSample()).toBeTruthy();
+    });
 });

--- a/test/generator-networks-creator/generator-networks-creator.test.ts
+++ b/test/generator-networks-creator/generator-networks-creator.test.ts
@@ -143,3 +143,82 @@ describe('Processing browser data', () => {
         }
     });
 });
+
+describe('Validation function', () => {
+    const networkGenerator = new GeneratorNetworksCreator();
+
+    test('Validates correct records', () => {
+        const validRecord = {
+            browserFingerprint: {
+                navigator: {
+                    appCodeName: 'Mozilla',
+                    userAgent: 'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/114.0.0.0 Safari/537.36'
+                }
+            }
+        };
+        expect(networkGenerator['validateRecord'](validRecord)).toBe(true);
+    });
+
+    test('Invalidates incorrect records', () => {
+        const invalidRecord1 = {
+            browserFingerprint: {
+                navigator: {
+                    appCodeName: 'NotMozilla',
+                    userAgent: 'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/114.0.0.0 Safari/537.36'
+                }
+            }
+        };
+        const invalidRecord2 = {
+            browserFingerprint: {
+                navigator: {
+                    appCodeName: 'Mozilla',
+                    userAgent: ''
+                }
+            }
+        };
+        expect(networkGenerator['validateRecord'](invalidRecord1)).toBe(false);
+        expect(networkGenerator['validateRecord'](invalidRecord2)).toBe(false);
+    });
+});
+
+describe('prepareRecords function', () => {
+    const networkGenerator = new GeneratorNetworksCreator();
+
+    test('Filters and processes records correctly', async () => {
+        const records = [
+            {
+                requestFingerprint: {
+                    headers: {
+                        'user-agent': 'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/114.0.0.0 Safari/537.36'
+                    }
+                },
+                browserFingerprint: {
+                    screen: { width: 1920, height: 1080 },
+                    userAgent: 'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/114.0.0.0 Safari/537.36',
+                    navigator: {
+                        appCodeName: 'Mozilla',
+                        userAgent: 'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/114.0.0.0 Safari/537.36'
+                    }
+                }
+            },
+            {
+                requestFingerprint: {
+                    headers: {
+                        'user-agent': 'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/114.0.0.0 Safari/537.36'
+                    }
+                },
+                browserFingerprint: {
+                    screen: { width: 800, height: 600 },
+                    userAgent: 'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/114.0.0.0 Safari/537.36',
+                    navigator: {
+                        appCodeName: 'Mozilla',
+                        userAgent: 'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/114.0.0.0 Safari/537.36'
+                    }
+                }
+            }
+        ];
+
+        const processedRecords = await networkGenerator['prepareRecords'](records, 'fingerprints');
+        expect(processedRecords.length).toBe(1);
+    });
+});


### PR DESCRIPTION
Fixes #342

Add input data validation before training models to ensure only real fingerprints are generated.

* **Validation Function**:
  - Add a validation function in `packages/generator-networks-creator/src/generator-networks-creator.ts` to check for real fingerprints.
  - Validate properties like `Navigator.appCodeName` and `Navigator.userAgent`.

* **Update Functions**:
  - Update `prepareRecords` function in `packages/generator-networks-creator/src/generator-networks-creator.ts` to call the validation function.
  - Update `setProbabilitiesAccordingToData` function in `packages/generative-bayesian-network/src/bayesian-network.ts` to only process validated data.

* **Tests**:
  - Add tests in `test/generator-networks-creator/generator-networks-creator.test.ts` to ensure the validation function works correctly and `prepareRecords` function calls the validation function.
  - Add tests in `test/generative-bayesian-network/generation.test.ts` to ensure `setProbabilitiesAccordingToData` function only processes validated data.
**https://github.com/NameNoQuality-create_pull#342

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/apify/fingerprint-suite/issues/342?shareId=XXXX-XXXX-XXXX-XXXX).