### PR TITLE
feat: allow header-generator to work on edge environemnts by removing readFileSync

### DIFF
--- a/packages/header-generator/src/header-generator.ts
+++ b/packages/header-generator/src/header-generator.ts
@@ -1,7 +1,7 @@
-import { readFileSync } from 'fs';
-
 import { BayesianNetwork, utils } from 'generative-bayesian-network';
 import ow from 'ow';
+import headersOrder from './data_files/headers-order.json'
+import uniqueBrowserStrings from './data_files/browser-helper-file.json'
 
 import {
     SUPPORTED_BROWSERS,
@@ -161,8 +161,6 @@ export class HeaderGenerator {
 
     private uniqueBrowsers: HttpBrowserObject[];
 
-    private headersOrder: string[];
-
     private relaxationOrder: (keyof typeof headerGeneratorOptionsShape)[] = [
         'locales',
         'devices',
@@ -196,9 +194,6 @@ export class HeaderGenerator {
             strict,
         };
         this.uniqueBrowsers = [];
-
-        this.headersOrder = JSON.parse(readFileSync(`${__dirname}/data_files/headers-order.json`).toString());
-        const uniqueBrowserStrings = JSON.parse(readFileSync(`${__dirname}/data_files/browser-helper-file.json`, 'utf8').toString());
 
         for (const browserString of uniqueBrowserStrings) {
             // There are headers without user agents in the datasets we used to configure the generator. They should be disregarded.
@@ -330,7 +325,7 @@ export class HeaderGenerator {
         return this.orderHeaders({
             ...generatedSample,
             ...requestDependentHeaders,
-        }, (this.headersOrder as Record<string, any>)[generatedHttpAndBrowser.name]);
+        }, (headersOrder)[generatedHttpAndBrowser.name as keyof typeof headersOrder]);
     }
 
     /**
@@ -512,6 +507,6 @@ export class HeaderGenerator {
             return [];
         }
 
-        return (this.headersOrder as Record<string, any>)[browser] ?? [];
+        return headersOrder[browser] ?? [];
     }
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,13 +1,14 @@
 {
     "extends": "./tsconfig.build.json",
     "compilerOptions": {
+        "resolveJsonModule": true,
         "baseUrl": ".",
         "paths": {
             "header-generator": ["packages/header-generator/src"],
             "fingerprint-generator": ["packages/fingerprint-generator/src"],
             "fingerprint-injector": ["packages/fingerprint-injector/src"],
             "generative-bayesian-network": ["packages/generative-bayesian-network/src"],
-            "generator-networks-creator": ["packages/generator-networks-creator/src"],
+            "generator-networks-creator": ["packages/generator-networks-creator/src"]
         }
     }
 }


### PR DESCRIPTION
I would like to use the `header-generator` library in a Cloudflare worker, but currently, I can't because it's using the `readFileSync` node API, which is not supported in Cloudflare Edge Environments.

I have enabled resolveJsonModule in tsconfig (although it was already enabled in tsconfig. build config) to allow code to read JSON files as imports. The impact is the same as we loaded the JSON files in the constructor and stored data as variables on the class. So switching to using import will have no noticeable memory difference and will function in the same way. 