### PR TITLE
chore: bump `turbo` to v2

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -40,7 +40,7 @@
                 "semver": "^7.3.8",
                 "ts-jest": "^29.0.0",
                 "ts-node": "^10.8.0",
-                "turbo": "^1.2.14",
+                "turbo": "^2.4.4",
                 "typescript": "^5.0.0",
                 "typescript-eslint": "^8.28.0"
             }
@@ -9063,95 +9063,102 @@
             "integrity": "sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q=="
         },
         "node_modules/turbo": {
-            "version": "1.10.14",
-            "resolved": "https://registry.npmjs.org/turbo/-/turbo-1.10.14.tgz",
-            "integrity": "sha512-hr9wDNYcsee+vLkCDIm8qTtwhJ6+UAMJc3nIY6+PNgUTtXcQgHxCq8BGoL7gbABvNWv76CNbK5qL4Lp9G3ZYRA==",
+            "version": "2.4.4",
+            "resolved": "https://registry.npmjs.org/turbo/-/turbo-2.4.4.tgz",
+            "integrity": "sha512-N9FDOVaY3yz0YCOhYIgOGYad7+m2ptvinXygw27WPLQvcZDl3+0Sa77KGVlLSiuPDChOUEnTKE9VJwLSi9BPGQ==",
             "dev": true,
+            "license": "MIT",
             "bin": {
                 "turbo": "bin/turbo"
             },
             "optionalDependencies": {
-                "turbo-darwin-64": "1.10.14",
-                "turbo-darwin-arm64": "1.10.14",
-                "turbo-linux-64": "1.10.14",
-                "turbo-linux-arm64": "1.10.14",
-                "turbo-windows-64": "1.10.14",
-                "turbo-windows-arm64": "1.10.14"
+                "turbo-darwin-64": "2.4.4",
+                "turbo-darwin-arm64": "2.4.4",
+                "turbo-linux-64": "2.4.4",
+                "turbo-linux-arm64": "2.4.4",
+                "turbo-windows-64": "2.4.4",
+                "turbo-windows-arm64": "2.4.4"
             }
         },
         "node_modules/turbo-darwin-64": {
-            "version": "1.10.14",
-            "resolved": "https://registry.npmjs.org/turbo-darwin-64/-/turbo-darwin-64-1.10.14.tgz",
-            "integrity": "sha512-I8RtFk1b9UILAExPdG/XRgGQz95nmXPE7OiGb6ytjtNIR5/UZBS/xVX/7HYpCdmfriKdVwBKhalCoV4oDvAGEg==",
+            "version": "2.4.4",
+            "resolved": "https://registry.npmjs.org/turbo-darwin-64/-/turbo-darwin-64-2.4.4.tgz",
+            "integrity": "sha512-5kPvRkLAfmWI0MH96D+/THnDMGXlFNmjeqNRj5grLKiry+M9pKj3pRuScddAXPdlxjO5Ptz06UNaOQrrYGTx1g==",
             "cpu": [
                 "x64"
             ],
             "dev": true,
+            "license": "MIT",
             "optional": true,
             "os": [
                 "darwin"
             ]
         },
         "node_modules/turbo-darwin-arm64": {
-            "version": "1.10.14",
-            "resolved": "https://registry.npmjs.org/turbo-darwin-arm64/-/turbo-darwin-arm64-1.10.14.tgz",
-            "integrity": "sha512-KAdUWryJi/XX7OD0alOuOa0aJ5TLyd4DNIYkHPHYcM6/d7YAovYvxRNwmx9iv6Vx6IkzTnLeTiUB8zy69QkG9Q==",
+            "version": "2.4.4",
+            "resolved": "https://registry.npmjs.org/turbo-darwin-arm64/-/turbo-darwin-arm64-2.4.4.tgz",
+            "integrity": "sha512-/gtHPqbGQXDFhrmy+Q/MFW2HUTUlThJ97WLLSe4bxkDrKHecDYhAjbZ4rN3MM93RV9STQb3Tqy4pZBtsd4DfCw==",
             "cpu": [
                 "arm64"
             ],
             "dev": true,
+            "license": "MIT",
             "optional": true,
             "os": [
                 "darwin"
             ]
         },
         "node_modules/turbo-linux-64": {
-            "version": "1.10.14",
-            "resolved": "https://registry.npmjs.org/turbo-linux-64/-/turbo-linux-64-1.10.14.tgz",
-            "integrity": "sha512-BOBzoREC2u4Vgpap/WDxM6wETVqVMRcM8OZw4hWzqCj2bqbQ6L0wxs1LCLWVrghQf93JBQtIGAdFFLyCSBXjWQ==",
+            "version": "2.4.4",
+            "resolved": "https://registry.npmjs.org/turbo-linux-64/-/turbo-linux-64-2.4.4.tgz",
+            "integrity": "sha512-SR0gri4k0bda56hw5u9VgDXLKb1Q+jrw4lM7WAhnNdXvVoep4d6LmnzgMHQQR12Wxl3KyWPbkz9d1whL6NTm2Q==",
             "cpu": [
                 "x64"
             ],
             "dev": true,
+            "license": "MIT",
             "optional": true,
             "os": [
                 "linux"
             ]
         },
         "node_modules/turbo-linux-arm64": {
-            "version": "1.10.14",
-            "resolved": "https://registry.npmjs.org/turbo-linux-arm64/-/turbo-linux-arm64-1.10.14.tgz",
-            "integrity": "sha512-D8T6XxoTdN5D4V5qE2VZG+/lbZX/89BkAEHzXcsSUTRjrwfMepT3d2z8aT6hxv4yu8EDdooZq/2Bn/vjMI32xw==",
+            "version": "2.4.4",
+            "resolved": "https://registry.npmjs.org/turbo-linux-arm64/-/turbo-linux-arm64-2.4.4.tgz",
+            "integrity": "sha512-COXXwzRd3vslQIfJhXUklgEqlwq35uFUZ7hnN+AUyXx7hUOLIiD5NblL+ETrHnhY4TzWszrbwUMfe2BYWtaPQg==",
             "cpu": [
                 "arm64"
             ],
             "dev": true,
+            "license": "MIT",
             "optional": true,
             "os": [
                 "linux"
             ]
         },
         "node_modules/turbo-windows-64": {
-            "version": "1.10.14",
-            "resolved": "https://registry.npmjs.org/turbo-windows-64/-/turbo-windows-64-1.10.14.tgz",
-            "integrity": "sha512-zKNS3c1w4i6432N0cexZ20r/aIhV62g69opUn82FLVs/zk3Ie0GVkSB6h0rqIvMalCp7enIR87LkPSDGz9K4UA==",
+            "version": "2.4.4",
+            "resolved": "https://registry.npmjs.org/turbo-windows-64/-/turbo-windows-64-2.4.4.tgz",
+            "integrity": "sha512-PV9rYNouGz4Ff3fd6sIfQy5L7HT9a4fcZoEv8PKRavU9O75G7PoDtm8scpHU10QnK0QQNLbE9qNxOAeRvF0fJg==",
             "cpu": [
                 "x64"
             ],
             "dev": true,
+            "license": "MIT",
             "optional": true,
             "os": [
                 "win32"
             ]
         },
         "node_modules/turbo-windows-arm64": {
-            "version": "1.10.14",
-            "resolved": "https://registry.npmjs.org/turbo-windows-arm64/-/turbo-windows-arm64-1.10.14.tgz",
-            "integrity": "sha512-rkBwrTPTxNSOUF7of8eVvvM+BkfkhA2OvpHM94if8tVsU+khrjglilp8MTVPHlyS9byfemPAmFN90oRIPB05BA==",
+            "version": "2.4.4",
+            "resolved": "https://registry.npmjs.org/turbo-windows-arm64/-/turbo-windows-arm64-2.4.4.tgz",
+            "integrity": "sha512-403sqp9t5sx6YGEC32IfZTVWkRAixOQomGYB8kEc6ZD+//LirSxzeCHCnM8EmSXw7l57U1G+Fb0kxgTcKPU/Lg==",
             "cpu": [
                 "arm64"
             ],
             "dev": true,
+            "license": "MIT",
             "optional": true,
             "os": [
                 "win32"
@@ -16342,58 +16349,58 @@
             "integrity": "sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q=="
         },
         "turbo": {
-            "version": "1.10.14",
-            "resolved": "https://registry.npmjs.org/turbo/-/turbo-1.10.14.tgz",
-            "integrity": "sha512-hr9wDNYcsee+vLkCDIm8qTtwhJ6+UAMJc3nIY6+PNgUTtXcQgHxCq8BGoL7gbABvNWv76CNbK5qL4Lp9G3ZYRA==",
+            "version": "2.4.4",
+            "resolved": "https://registry.npmjs.org/turbo/-/turbo-2.4.4.tgz",
+            "integrity": "sha512-N9FDOVaY3yz0YCOhYIgOGYad7+m2ptvinXygw27WPLQvcZDl3+0Sa77KGVlLSiuPDChOUEnTKE9VJwLSi9BPGQ==",
             "dev": true,
             "requires": {
-                "turbo-darwin-64": "1.10.14",
-                "turbo-darwin-arm64": "1.10.14",
-                "turbo-linux-64": "1.10.14",
-                "turbo-linux-arm64": "1.10.14",
-                "turbo-windows-64": "1.10.14",
-                "turbo-windows-arm64": "1.10.14"
+                "turbo-darwin-64": "2.4.4",
+                "turbo-darwin-arm64": "2.4.4",
+                "turbo-linux-64": "2.4.4",
+                "turbo-linux-arm64": "2.4.4",
+                "turbo-windows-64": "2.4.4",
+                "turbo-windows-arm64": "2.4.4"
             }
         },
         "turbo-darwin-64": {
-            "version": "1.10.14",
-            "resolved": "https://registry.npmjs.org/turbo-darwin-64/-/turbo-darwin-64-1.10.14.tgz",
-            "integrity": "sha512-I8RtFk1b9UILAExPdG/XRgGQz95nmXPE7OiGb6ytjtNIR5/UZBS/xVX/7HYpCdmfriKdVwBKhalCoV4oDvAGEg==",
+            "version": "2.4.4",
+            "resolved": "https://registry.npmjs.org/turbo-darwin-64/-/turbo-darwin-64-2.4.4.tgz",
+            "integrity": "sha512-5kPvRkLAfmWI0MH96D+/THnDMGXlFNmjeqNRj5grLKiry+M9pKj3pRuScddAXPdlxjO5Ptz06UNaOQrrYGTx1g==",
             "dev": true,
             "optional": true
         },
         "turbo-darwin-arm64": {
-            "version": "1.10.14",
-            "resolved": "https://registry.npmjs.org/turbo-darwin-arm64/-/turbo-darwin-arm64-1.10.14.tgz",
-            "integrity": "sha512-KAdUWryJi/XX7OD0alOuOa0aJ5TLyd4DNIYkHPHYcM6/d7YAovYvxRNwmx9iv6Vx6IkzTnLeTiUB8zy69QkG9Q==",
+            "version": "2.4.4",
+            "resolved": "https://registry.npmjs.org/turbo-darwin-arm64/-/turbo-darwin-arm64-2.4.4.tgz",
+            "integrity": "sha512-/gtHPqbGQXDFhrmy+Q/MFW2HUTUlThJ97WLLSe4bxkDrKHecDYhAjbZ4rN3MM93RV9STQb3Tqy4pZBtsd4DfCw==",
             "dev": true,
             "optional": true
         },
         "turbo-linux-64": {
-            "version": "1.10.14",
-            "resolved": "https://registry.npmjs.org/turbo-linux-64/-/turbo-linux-64-1.10.14.tgz",
-            "integrity": "sha512-BOBzoREC2u4Vgpap/WDxM6wETVqVMRcM8OZw4hWzqCj2bqbQ6L0wxs1LCLWVrghQf93JBQtIGAdFFLyCSBXjWQ==",
+            "version": "2.4.4",
+            "resolved": "https://registry.npmjs.org/turbo-linux-64/-/turbo-linux-64-2.4.4.tgz",
+            "integrity": "sha512-SR0gri4k0bda56hw5u9VgDXLKb1Q+jrw4lM7WAhnNdXvVoep4d6LmnzgMHQQR12Wxl3KyWPbkz9d1whL6NTm2Q==",
             "dev": true,
             "optional": true
         },
         "turbo-linux-arm64": {
-            "version": "1.10.14",
-            "resolved": "https://registry.npmjs.org/turbo-linux-arm64/-/turbo-linux-arm64-1.10.14.tgz",
-            "integrity": "sha512-D8T6XxoTdN5D4V5qE2VZG+/lbZX/89BkAEHzXcsSUTRjrwfMepT3d2z8aT6hxv4yu8EDdooZq/2Bn/vjMI32xw==",
+            "version": "2.4.4",
+            "resolved": "https://registry.npmjs.org/turbo-linux-arm64/-/turbo-linux-arm64-2.4.4.tgz",
+            "integrity": "sha512-COXXwzRd3vslQIfJhXUklgEqlwq35uFUZ7hnN+AUyXx7hUOLIiD5NblL+ETrHnhY4TzWszrbwUMfe2BYWtaPQg==",
             "dev": true,
             "optional": true
         },
         "turbo-windows-64": {
-            "version": "1.10.14",
-            "resolved": "https://registry.npmjs.org/turbo-windows-64/-/turbo-windows-64-1.10.14.tgz",
-            "integrity": "sha512-zKNS3c1w4i6432N0cexZ20r/aIhV62g69opUn82FLVs/zk3Ie0GVkSB6h0rqIvMalCp7enIR87LkPSDGz9K4UA==",
+            "version": "2.4.4",
+            "resolved": "https://registry.npmjs.org/turbo-windows-64/-/turbo-windows-64-2.4.4.tgz",
+            "integrity": "sha512-PV9rYNouGz4Ff3fd6sIfQy5L7HT9a4fcZoEv8PKRavU9O75G7PoDtm8scpHU10QnK0QQNLbE9qNxOAeRvF0fJg==",
             "dev": true,
             "optional": true
         },
         "turbo-windows-arm64": {
-            "version": "1.10.14",
-            "resolved": "https://registry.npmjs.org/turbo-windows-arm64/-/turbo-windows-arm64-1.10.14.tgz",
-            "integrity": "sha512-rkBwrTPTxNSOUF7of8eVvvM+BkfkhA2OvpHM94if8tVsU+khrjglilp8MTVPHlyS9byfemPAmFN90oRIPB05BA==",
+            "version": "2.4.4",
+            "resolved": "https://registry.npmjs.org/turbo-windows-arm64/-/turbo-windows-arm64-2.4.4.tgz",
+            "integrity": "sha512-403sqp9t5sx6YGEC32IfZTVWkRAixOQomGYB8kEc6ZD+//LirSxzeCHCnM8EmSXw7l57U1G+Fb0kxgTcKPU/Lg==",
             "dev": true,
             "optional": true
         },

--- a/package.json
+++ b/package.json
@@ -73,7 +73,7 @@
         "semver": "^7.3.8",
         "ts-jest": "^29.0.0",
         "ts-node": "^10.8.0",
-        "turbo": "^1.2.14",
+        "turbo": "^2.4.4",
         "typescript": "^5.0.0",
         "typescript-eslint": "^8.28.0"
     },

--- a/turbo.json
+++ b/turbo.json
@@ -1,6 +1,5 @@
 {
-    "baseBranch": "origin/master",
-    "pipeline": {
+    "tasks": {
         "build": {
             "dependsOn": [
                 "^build"


### PR DESCRIPTION
Bumps `turbo` to v2 and updates the related config files. Unlocks the automatic `package-lock.json` renovate-bot update (was failing with new turbo with old config).