### PR TITLE
feat: add the `priority` header to compatible browser header sets

### DIFF
--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
         "release": "./scripts/publish.sh",
         "test": "jest --silent",
         "lint": "eslint && prettier . --check",
-        "lint:fix": "eslint --fix",
+        "lint:fix": "eslint --fix && prettier . --write",
         "buildNetwork": "turbo run build && ./scripts/netgen.sh && turbo run build",
         "benchmark": "ts-node ./test/antibot-services/live-testing/cloudflare.ts"
     },

--- a/packages/header-generator/src/data_files/headers-order.json
+++ b/packages/header-generator/src/data_files/headers-order.json
@@ -53,6 +53,7 @@
         "Accept-Encoding",
         "Accept-Language",
         "Cookie",
+        "Priority",
         ":method",
         ":authority",
         ":scheme",
@@ -74,7 +75,8 @@
         "referer",
         "accept-encoding",
         "accept-language",
-        "cookie"
+        "cookie",
+        "priority"
     ],
     "firefox": [
         "Host",
@@ -93,6 +95,7 @@
         "Sec-Fetch-Mode",
         "Sec-Fetch-Site",
         "Sec-Fetch-User",
+        "Priority",
         ":method",
         ":path",
         ":authority",
@@ -111,7 +114,8 @@
         "sec-fetch-mode",
         "sec-fetch-site",
         "sec-fetch-user",
-        "te"
+        "te",
+        "priority"
     ],
     "edge": []
 }

--- a/packages/header-generator/src/header-generator.ts
+++ b/packages/header-generator/src/header-generator.ts
@@ -416,8 +416,8 @@ export class HeaderGenerator {
         if (hasPriority) {
             generatedSample[
                 generatedHttpAndBrowser.httpVersion === '2'
-                ? 'priority'
-                : 'Priority'
+                    ? 'priority'
+                    : 'Priority'
             ] = 'u=0';
         }
 

--- a/packages/header-generator/src/header-generator.ts
+++ b/packages/header-generator/src/header-generator.ts
@@ -408,6 +408,19 @@ export class HeaderGenerator {
             generatedSample[secFetchAttributeNames.dest] = 'document';
         }
 
+        const hasPriority =
+            (isChrome && generatedHttpAndBrowser.version[0] >= 124) ||
+            (isFirefox && generatedHttpAndBrowser.version[0] >= 128) ||
+            (isEdge && generatedHttpAndBrowser.version[0] >= 124);
+
+        if (hasPriority) {
+            generatedSample[
+                generatedHttpAndBrowser.httpVersion === '2'
+                ? 'priority'
+                : 'Priority'
+            ] = 'u=0';
+        }
+
         for (const attribute of Object.keys(generatedSample)) {
             if (
                 attribute.toLowerCase() === 'connection' &&


### PR DESCRIPTION
Injects a static `priority` header into compatible header sets (based on the compatibility header from [MDN](https://developer.mozilla.org/en-US/docs/Web/HTTP/Reference/Headers/Priority)).

Generating this field based on the collected data isn't feasible, since the Priority header is resource-type bound (is the resource a document, image, stylesheet...?) rather than `user-agent`dependent. In this regard, it's similar to the `sec-fetch-*` headers.

This PR sets the `priority` header to `u=0`, setting the highest possible priority for the current resource.

Closes #351 