### PR TITLE
chore(ci): fix release pipeline (whitelist envvar in `turbo.json`)

### DIFF
--- a/scripts/copy.ts
+++ b/scripts/copy.ts
@@ -28,7 +28,10 @@ const localPackages = readdirSync(join(__dirname, '../packages'));
 
 if (!process.env.GIT_TAG || semver.valid(process.env.GIT_TAG) === null) {
     throw new Error(
-        'GIT_TAG environment variable is not set or is not a valid semver tag!',
+        `GIT_TAG environment variable is not set or is not a valid semver tag!
+
+GIT_TAG: ${process.env.GIT_TAG}
+GITHUB_REF: ${process.env.GITHUB_REF}`,
     );
 }
 

--- a/turbo.json
+++ b/turbo.json
@@ -14,7 +14,8 @@
             ],
             "outputs": [
                 "dist/**"
-            ]
+            ],
+            "env": ["GIT_TAG"]
         },
         "clean": {
             "outputs": []


### PR DESCRIPTION
The recent switch to `turbo@v2` enforces `env-mode: strict` behavior, which removes all envvars from the script environment. This broke the automatic CI release pipeline.