### PR TITLE
fix(revert): remove generated `priority` header from the header sets

### DIFF
--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
         "release": "./scripts/publish.sh",
         "test": "jest --silent",
         "lint": "eslint && prettier . --check",
-        "lint:fix": "eslint --fix",
+        "lint:fix": "eslint --fix && prettier . --write",
         "buildNetwork": "turbo run build && ./scripts/netgen.sh && turbo run build",
         "benchmark": "ts-node ./test/antibot-services/live-testing/cloudflare.ts"
     },

--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
         "release": "./scripts/publish.sh",
         "test": "jest --silent",
         "lint": "eslint && prettier . --check",
-        "lint:fix": "eslint --fix && prettier . --write",
+        "lint:fix": "eslint --fix",
         "buildNetwork": "turbo run build && ./scripts/netgen.sh && turbo run build",
         "benchmark": "ts-node ./test/antibot-services/live-testing/cloudflare.ts"
     },

--- a/packages/header-generator/src/data_files/headers-order.json
+++ b/packages/header-generator/src/data_files/headers-order.json
@@ -53,7 +53,6 @@
         "Accept-Encoding",
         "Accept-Language",
         "Cookie",
-        "Priority",
         ":method",
         ":authority",
         ":scheme",
@@ -75,8 +74,7 @@
         "referer",
         "accept-encoding",
         "accept-language",
-        "cookie",
-        "priority"
+        "cookie"
     ],
     "firefox": [
         "Host",
@@ -95,7 +93,6 @@
         "Sec-Fetch-Mode",
         "Sec-Fetch-Site",
         "Sec-Fetch-User",
-        "Priority",
         ":method",
         ":path",
         ":authority",
@@ -114,8 +111,7 @@
         "sec-fetch-mode",
         "sec-fetch-site",
         "sec-fetch-user",
-        "te",
-        "priority"
+        "te"
     ],
     "edge": []
 }

--- a/packages/header-generator/src/header-generator.ts
+++ b/packages/header-generator/src/header-generator.ts
@@ -415,19 +415,6 @@ export class HeaderGenerator {
             generatedSample[secFetchAttributeNames.dest] = 'document';
         }
 
-        const hasPriority =
-            (isChrome && generatedHttpAndBrowser.version[0] >= 124) ||
-            (isFirefox && generatedHttpAndBrowser.version[0] >= 128) ||
-            (isEdge && generatedHttpAndBrowser.version[0] >= 124);
-
-        if (hasPriority) {
-            generatedSample[
-                generatedHttpAndBrowser.httpVersion === '2'
-                    ? 'priority'
-                    : 'Priority'
-            ] = 'u=0';
-        }
-
         for (const attribute of Object.keys(generatedSample)) {
             if (
                 attribute.toLowerCase() === 'connection' &&


### PR DESCRIPTION
Empirical evidence shows that generating the `priority` headers makes browsers more detectable and breaks certain scenarios. 

This PR reverts #367 .