### PR TITLE
chore: reenable the monthly model updates

### DIFF
--- a/.github/workflows/model-updater.yml
+++ b/.github/workflows/model-updater.yml
@@ -2,8 +2,8 @@ name: Model updater
 
 on:
     # Triggers the workflow every month
-    # schedule:
-    #   - cron: "0 0 1 * *"
+    schedule:
+        - cron: "0 0 1 * *"
     workflow_dispatch:
 
 jobs:

--- a/.github/workflows/model-updater.yml
+++ b/.github/workflows/model-updater.yml
@@ -3,7 +3,7 @@ name: Model updater
 on:
     # Triggers the workflow every month
     schedule:
-        - cron: "0 0 1 * *"
+        - cron: '0 0 1 * *'
     workflow_dispatch:
 
 jobs:


### PR DESCRIPTION
Hi, 

Is it possible to add back the monthly schedule to the Model updater.

As of now, the header data file seems to be more than 6 months old.

Is it possible to at least publish a recent update ? 

Thanks in advance!