### PR TITLE
fix: redefine window screen properly

### DIFF
--- a/packages/fingerprint-injector/src/fingerprint-injector.ts
+++ b/packages/fingerprint-injector/src/fingerprint-injector.ts
@@ -30,6 +30,9 @@ declare function overrideDocumentDimensionsProps(
 declare function overrideWindowDimensionsProps(
     props: Record<string, number>,
 ): void;
+declare function overrideWindowScreen(
+    props: Record<string, number>,
+): void;
 declare function overrideBattery(
     batteryInfo?: Record<string, string | number>,
 ): void;
@@ -263,7 +266,7 @@ export class FingerprintInjector {
             }
             overrideInstancePrototype(window.navigator, navigatorProps);
 
-            overrideInstancePrototype(window.screen, newScreen);
+            overrideWindowScreen(newScreen);
             overrideWindowDimensionsProps(windowScreenProps);
             overrideDocumentDimensionsProps(documentScreenProps);
 

--- a/packages/fingerprint-injector/src/utils.js
+++ b/packages/fingerprint-injector/src/utils.js
@@ -498,6 +498,16 @@ function overrideScreenByReassigning(target, newProperties) {
     }
 }
 
+function overrideWindowScreen(props) {
+    for (const [prop, value] of Object.entries(props)) {
+        redefineProperty(window.screen, prop, {
+            get() {
+                return value;
+            },
+        });
+    }
+}
+
 function overrideWindowDimensionsProps(props) {
     try {
         overrideScreenByReassigning(window, props);


### PR DESCRIPTION
when calling `overrideInstancePrototype`, the `overrideGetterWithProxy` is been called, which in turn tries to run:
```
const fn = Object.getOwnPropertyDescriptor(masterObject, propertyName).get;
```

This returns `undefined` for 
```
Object.getOwnPropertyDescriptor(window.screen, 'availHeight');
```

and basically crashes when trying to access `get`

This results in screen properties been reset to `undefined` which is seen on FingreprintJs test:

```
{
  ...
  "screenFrame": {
    "value": [
      0,
      0,
      0,
      0
    ],
    "duration": 2
  },
  ...
}
```

This fix just redefined the `get` accessor without playing with proxies