### PR TITLE
chore: fix test in CI publish workflow

### DIFF
--- a/.github/workflows/release-publish.yml
+++ b/.github/workflows/release-publish.yml
@@ -6,6 +6,7 @@ on:
 jobs:
     test_and_sync:
         uses: apify/fingerprint-suite/.github/workflows/test-and-sync.yml@master
+        secrets: inherit
 
     publish_latest:
         name: Publish latest


### PR DESCRIPTION
Passes missing secrets to the `test-and-sync` workflow on release. 