### PR TITLE
refactor: use default parameter of FingerprintGenerator.getFingerprint()

### DIFF
--- a/packages/fingerprint-injector/src/fingerprint-injector.ts
+++ b/packages/fingerprint-injector/src/fingerprint-injector.ts
@@ -339,7 +339,7 @@ export async function newInjectedContext(
     const generator = new FingerprintGenerator();
     const fingerprintWithHeaders =
         options?.fingerprint ??
-        generator.getFingerprint(options?.fingerprintOptions ?? {});
+        generator.getFingerprint(options?.fingerprintOptions);
 
     const { fingerprint, headers } = fingerprintWithHeaders;
     const context = await browser.newContext({
@@ -376,7 +376,7 @@ export async function newInjectedPage(
     const generator = new FingerprintGenerator();
     const fingerprintWithHeaders =
         options?.fingerprint ??
-        generator.getFingerprint(options?.fingerprintOptions ?? {});
+        generator.getFingerprint(options?.fingerprintOptions);
 
     const page = await browser.newPage();
 


### PR DESCRIPTION
https://github.com/apify/fingerprint-suite/blob/d4336bb3596589ff568b2d6c31a87cf4a45d1936/packages/fingerprint-generator/src/fingerprint-generator.ts#L154-L157

The `options` parameter of `FingerprintGenerator.getFingerprint()` has `{}` as its default value. So there's no need to pass `{}` when the `options?.fingerprintOptions` is `undefined`.