### PR TITLE
chore(ci): fix path to the `release_python` workflow

### DIFF
--- a/.github/workflows/model-updater.yml
+++ b/.github/workflows/model-updater.yml
@@ -184,5 +184,5 @@ jobs:
     release_python:
         name: Public new Python package to PyPI
         needs: commit_model
-        uses: .github/workflows/release_python.yaml
+        uses: ./.github/workflows/release_python.yaml
         secrets: inherit


### PR DESCRIPTION
Recent changes from #447 break model updater workflow due to invalid syntax

Failing workflow e.g. here: https://github.com/apify/fingerprint-suite/actions/runs/17424508126