### PR TITLE
chore(ci): fix automatic Python model updater

### DIFF
--- a/.github/workflows/model-updater.yml
+++ b/.github/workflows/model-updater.yml
@@ -155,7 +155,7 @@ jobs:
                   # Bump python project version
                   uv version --bump minor
                   # Update changelog
-                  sed -i "5i## $(uv version --short) - ($(date "+%Y-%m-%d"))\n- Updated data. Same as npm package \`fingerprint-generator\` version \`$version\`\n " CHANGELOG.md
+                  sed -i "5i## $(uv version --short) - ($(date "+%Y-%m-%d"))\n\n- Updated data. Same as npm package \`fingerprint-generator\` version \`$version\`\n" CHANGELOG.md
 
             - name: Push new model
               uses: stefanzweifel/git-auto-commit-action@v6

--- a/apify_fingerprint_datapoints/CHANGELOG.md
+++ b/apify_fingerprint_datapoints/CHANGELOG.md
@@ -3,8 +3,9 @@
 All notable changes to this project will be documented in this file.
 
 ## 0.2.0 - (2025-09-03)
+
 - Updated data. Same as npm package `fingerprint-generator` version `2.1.71`
- 
+
 ## 0.1.0 - (2025-08-28)
 
 - Updated data. Same as npm package `fingerprint-generator` version `2.1.70`


### PR DESCRIPTION
Fixes formatting issues blocking the automatic package release (see e.g. https://github.com/apify/fingerprint-suite/actions/runs/17427520757/job/49477937261)