### PR TITLE
ci: Duplicate pypi publishing to model-updater

### DIFF
--- a/.github/workflows/model-updater.yml
+++ b/.github/workflows/model-updater.yml
@@ -181,8 +181,25 @@ jobs:
 
                       The only difference between this release and the previous one is the model used to generate fingerprints.
 
-    release_python:
-        name: Public new Python package to PyPI
-        needs: commit_model
-        uses: ./.github/workflows/release_python.yaml
-        secrets: inherit
+    publish_to_pypi: # Duplicate of release_python.yaml due to https://github.com/pypa/gh-action-pypi-publish/issues/166
+        name: Publish to PyPI
+        runs-on: ubuntu-latest
+        permissions:
+            contents: write
+            id-token: write # Required for OIDC authentication.
+        environment:
+            name: pypi
+            url: https://pypi.org/project/crawlee
+        steps:
+            - uses: actions/checkout@v5
+            - uses: actions/setup-python@v6
+              with:
+                  python-version: '3.13'
+            - uses: astral-sh/setup-uv@v6
+            - name: Build project
+              shell: bash
+              run: uv build
+
+            # Publishes the package to PyPI using PyPA official GitHub action with OIDC authentication.
+            - name: Publish package to PyPI
+              uses: pypa/gh-action-pypi-publish@release/v1


### PR DESCRIPTION
Publishing workflow does not work well when reusable; duplicate the code to the model-updater file.
https://github.com/pypa/gh-action-pypi-publish/issues/166