### PR TITLE
feat: add |skipScreenFingerprint| option to handle missing screen properties

### DIFF
--- a/packages/fingerprint-generator/src/fingerprint-generator.ts
+++ b/packages/fingerprint-generator/src/fingerprint-generator.ts
@@ -82,7 +82,7 @@ export type VideoCard = {
 };
 
 export type Fingerprint = {
-    screen: ScreenFingerprint;
+    screen: ScreenFingerprint | null;
     navigator: NavigatorFingerprint;
     videoCodecs: Record<string, string>;
     audioCodecs: Record<string, string>;
@@ -119,6 +119,13 @@ export interface FingerprintGeneratorOptions extends HeaderGeneratorOptions {
      * Try enabling this if you are experiencing performance issues with the fingerprint injection.
      */
     slim?: boolean;
+    /**
+     * When set to true, allows fingerprint generation without screen properties.
+     * This can be useful when screen fingerprint is not required or to avoid fingerprint generation issue.
+     *
+     * **Note:** When enabled, the `screen` property in the generated fingerprint will be null.
+     */
+    skipScreenFingerprint?: boolean;
 }
 
 /**
@@ -242,7 +249,14 @@ export class FingerprintGenerator extends HeaderGenerator {
                 }
             }
 
-            if (!fingerprint.screen) continue; // fix? sometimes, fingerprints are generated 90% empty/null. This is just a workaround.
+            if (!fingerprint.screen) {
+                // If skipScreenFingerprint is enabled, allow fingerprint without screen
+                if (options.skipScreenFingerprint) {
+                    fingerprint.screen = null;
+                } else {
+                    continue; // fix? sometimes, fingerprints are generated 90% empty/null. This is just a workaround.
+                }
+            }
 
             // Manually add the set of accepted languages required by the input
             const acceptLanguageHeaderValue =


### PR DESCRIPTION
Add a new `skipScreenFingerprint` option to FingerprintGeneratorOptions that allows users to generate fingerprints without requiring screen properties. This eliminates the need for silent retries when screen generation fails.

- Added `skipScreenFingerprint` boolean option to FingerprintGeneratorOptions
- Updated Fingerprint type to allow screen property to be null (ScreenFingerprint | null)
- Replace workaround `if (!fingerprint.screen) continue` with explicit user-controlled behavior

Benefit:
- Improves reliability by avoiding unnecessary generation retries and better performance when screen properties are not needed

Closes: #479