### PR TITLE
feat: Overriding WebWorker Navigator

### DIFF
--- a/packages/fingerprint-injector/src/fingerprint-injector.ts
+++ b/packages/fingerprint-injector/src/fingerprint-injector.ts
@@ -5,6 +5,7 @@ import {
     Fingerprint,
     FingerprintGenerator,
     FingerprintGeneratorOptions,
+    NavigatorFingerprint,
     type UserAgentData,
 } from 'fingerprint-generator';
 import {
@@ -42,6 +43,7 @@ declare function overrideIntlAPI(language: string): void;
 declare function overrideStatic(): void;
 declare function runHeadlessFixes(): void;
 declare function blockWebRTC(): void;
+declare function overrideWebWorker(navigatorFingerprint: NavigatorFingerprint): void;
 
 /**
  * Fingerprint injector class.
@@ -251,6 +253,8 @@ export class FingerprintInjector {
                 clientWidth,
             };
 
+            // @ts-expect-error internal browser code
+            overrideWebWorker(fp.navigator);
             runHeadlessFixes();
 
             if (mockWebRTC) blockWebRTC();


### PR DESCRIPTION
Hi there!

I recently found this [website](https://deviceandbrowserinfo.com/are_you_a_bot) which flagged my project with inconsistent Web Works values. 
I believe the solution would be great against Anti Bot services.

Before patch:
<img width="640" height="480" alt="bot" src="https://github.com/user-attachments/assets/31c174b3-4803-4f4d-b03a-0dbfc9c7d5a0" />

After patch:
<img width="640" height="480" alt="human" src="https://github.com/user-attachments/assets/1f02006e-63ab-4878-b5d2-ab6f54dc5a01" />


Close: https://github.com/apify/fingerprint-suite/issues/64