### PR TITLE
chore: link network generator with pnpm workspaces

### DIFF
--- a/package.json
+++ b/package.json
@@ -57,6 +57,7 @@
         "eslint-config-prettier": "^10.1.1",
         "fast-csv": "^5.0.0",
         "gen-esm-wrapper": "^1.1.3",
+        "generator-networks-creator": "workspace:*",
         "globals": "^17.0.0",
         "globby": "^15.0.0",
         "husky": "^9.0.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -50,6 +50,9 @@ importers:
       gen-esm-wrapper:
         specifier: ^1.1.3
         version: 1.1.3
+      generator-networks-creator:
+        specifier: workspace:*
+        version: link:packages/generator-networks-creator
       globals:
         specifier: ^17.0.0
         version: 17.5.0


### PR DESCRIPTION
With `npm` workspaces, the linker creates `node_modules` symlinks for all local packages (so `generator-networks-creator` was visible from the network building script). 

With `pnpm`, this is no longer the case - unspecified dependencies are omitted from the `node_modules` linking.

This fixes the failing [Model updater run](https://github.com/apify/fingerprint-suite/actions/runs/25197127008).
