### PR TITLE
chore: fix `pnpm` prerelease script

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
         "clean": "turbo run clean",
         "build": "turbo run build",
         "postbuild": "node ./scripts/typescript_fixes.mjs",
-        "prerelease": "pnpm build -- --force && turbo run copy --force --concurrency=1",
+        "prerelease": "pnpm build --force && turbo run copy --force --concurrency=1",
         "release": "./scripts/publish.sh",
         "test": "vitest",
         "lint": "eslint && prettier . --check",


### PR DESCRIPTION
Unlike `npm`, `pnpm` forwards the `--` (double dash) to the following command. This was breaking the prerelease CI job, as the `--force` wasn't treated as the `turbo run build` option and was (mistakingly) passed on.
