### PR TITLE
fix: normalize generated viewport dimensions

### DIFF
--- a/packages/fingerprint-generator/src/fingerprint-generator.ts
+++ b/packages/fingerprint-generator/src/fingerprint-generator.ts
@@ -341,7 +341,7 @@ export class FingerprintGenerator extends HeaderGenerator {
         };
 
         return {
-            screen,
+            screen: this.normalizeScreenFingerprint(screen),
             navigator,
             audioCodecs,
             videoCodecs,
@@ -351,5 +351,46 @@ export class FingerprintGenerator extends HeaderGenerator {
             multimediaDevices,
             fonts,
         } as Fingerprint;
+    }
+
+    private normalizeScreenFingerprint(
+        screen: ScreenFingerprint,
+    ): ScreenFingerprint {
+        const outerWidth =
+            this.positiveFiniteNumber(screen.outerWidth) ??
+            this.positiveFiniteNumber(screen.width) ??
+            1;
+        const outerHeight =
+            this.positiveFiniteNumber(screen.outerHeight) ??
+            this.positiveFiniteNumber(screen.height) ??
+            1;
+        const innerWidth = Math.min(
+            this.positiveFiniteNumber(screen.innerWidth) ?? outerWidth,
+            outerWidth,
+        );
+        const innerHeight = Math.min(
+            this.positiveFiniteNumber(screen.innerHeight) ?? outerHeight,
+            outerHeight,
+        );
+
+        return {
+            ...screen,
+            outerWidth,
+            outerHeight,
+            innerWidth,
+            innerHeight,
+            clientWidth: Math.min(
+                this.positiveFiniteNumber(screen.clientWidth) ?? innerWidth,
+                innerWidth,
+            ),
+            clientHeight: Math.min(
+                this.positiveFiniteNumber(screen.clientHeight) ?? innerHeight,
+                innerHeight,
+            ),
+        };
+    }
+
+    private positiveFiniteNumber(value: number): number | undefined {
+        return Number.isFinite(value) && value > 0 ? value : undefined;
     }
 }

--- a/packages/fingerprint-injector/src/fingerprint-injector.ts
+++ b/packages/fingerprint-injector/src/fingerprint-injector.ts
@@ -43,6 +43,22 @@ declare function overrideStatic(): void;
 declare function runHeadlessFixes(): void;
 declare function blockWebRTC(): void;
 
+function getViewportFromScreen(screen: Fingerprint['screen']): {
+    width: number;
+    height: number;
+} {
+    return {
+        width:
+            Number.isFinite(screen.innerWidth) && screen.innerWidth > 0
+                ? screen.innerWidth
+                : screen.width,
+        height:
+            Number.isFinite(screen.innerHeight) && screen.innerHeight > 0
+                ? screen.innerHeight
+                : screen.height,
+    };
+}
+
 /**
  * Fingerprint injector class.
  * @class
@@ -141,6 +157,7 @@ export class FingerprintInjector {
         const { fingerprint, headers } = browserFingerprintWithHeaders;
         const enhancedFingerprint = this._enhanceFingerprint(fingerprint);
         const { screen, userAgent } = enhancedFingerprint;
+        const viewport = getViewportFromScreen(screen);
 
         await page.setUserAgent(userAgent);
 
@@ -152,8 +169,8 @@ export class FingerprintInjector {
             ).send('Page.setDeviceMetricsOverride', {
                 screenHeight: screen.height,
                 screenWidth: screen.width,
-                width: screen.width,
-                height: screen.height,
+                width: viewport.width,
+                height: viewport.height,
                 mobile: /phone|android|mobile/i.test(userAgent),
                 screenOrientation:
                     screen.height > screen.width
@@ -342,13 +359,14 @@ export async function newInjectedContext(
         generator.getFingerprint(options?.fingerprintOptions);
 
     const { fingerprint, headers } = fingerprintWithHeaders;
+    const viewport = getViewportFromScreen(fingerprint.screen);
     const context = await browser.newContext({
         userAgent: fingerprint.navigator.userAgent,
         colorScheme: 'dark',
         ...options?.newContextOptions,
         viewport: {
-            width: fingerprint.screen.width,
-            height: fingerprint.screen.height,
+            width: viewport.width,
+            height: viewport.height,
             ...options?.newContextOptions?.viewport,
         },
         extraHTTPHeaders: {

--- a/test/fingerprint-generator/generation.test.ts
+++ b/test/fingerprint-generator/generation.test.ts
@@ -84,6 +84,29 @@ describe('Generation tests', () => {
             expect(field).toBeDefined();
         }
     });
+
+    test('Generates non-zero viewport dimensions for desktop Chrome fingerprints', () => {
+        const fingerprintGenerator = new FingerprintGenerator({
+            devices: ['desktop'],
+            browsers: ['chrome'],
+            operatingSystems: ['macos'],
+        });
+
+        for (let x = 0; x < 100; x++) {
+            const {
+                fingerprint: { screen },
+            } = fingerprintGenerator.getFingerprint();
+
+            expect(screen.innerWidth).toBeGreaterThan(0);
+            expect(screen.innerHeight).toBeGreaterThan(0);
+            expect(screen.clientWidth).toBeGreaterThan(0);
+            expect(screen.clientHeight).toBeGreaterThan(0);
+            expect(screen.innerWidth).toBeLessThanOrEqual(screen.outerWidth);
+            expect(screen.innerHeight).toBeLessThanOrEqual(screen.outerHeight);
+            expect(screen.clientWidth).toBeLessThanOrEqual(screen.innerWidth);
+            expect(screen.clientHeight).toBeLessThanOrEqual(screen.innerHeight);
+        }
+    });
 });
 
 describe('Generate fingerprints with basic constraints', () => {


### PR DESCRIPTION
Fixes #6.

## Summary

Fixes generated fingerprints that expose zero viewport dimensions such as `innerWidth`, `innerHeight`, `clientWidth`, and `clientHeight`.

## Why

Issue #6 reports Chrome/macOS fingerprints where those viewport-related fields are `0` while the surrounding screen fields are populated. That creates an internally inconsistent fingerprint and can be flagged by services such as Pixelscan.

## Changes

- Normalize generated screen fingerprints before returning them from `FingerprintGenerator`.
- Preserve existing non-zero values, but fill missing or zero viewport/client dimensions from coherent outer-window dimensions.
- Use `innerWidth` and `innerHeight` as the Playwright/Puppeteer viewport dimensions while keeping `screen.width` and `screen.height` as physical screen dimensions.
- Add regression coverage for non-zero coherent desktop Chrome viewport dimensions.

## Verification

- `cmd /c node_modules\.bin\vitest.CMD run test\fingerprint-generator\generation.test.ts`
- `cmd /c node_modules\.bin\tsc.CMD --noEmit -p tsconfig.json`
- `cmd /c node_modules\.bin\prettier.CMD --check packages\fingerprint-generator\src\fingerprint-generator.ts packages\fingerprint-injector\src\fingerprint-injector.ts test\fingerprint-generator\generation.test.ts`

Note: `cmd /c node_modules\.bin\tsc.CMD --noEmit -p test\tsconfig.json` currently fails on pre-existing `header-generator` test type issues unrelated to this patch.