### PR TITLE
fix(generator-networks-creator): reject invalid screen viewport dims at schema layer

### DIFF
--- a/packages/generator-networks-creator/src/record-schema.ts
+++ b/packages/generator-networks-creator/src/record-schema.ts
@@ -247,10 +247,10 @@ export async function getRecordSchema() {
                             height: z.number().positive(),
                             availWidth: z.number().positive(),
                             availHeight: z.number().positive(),
-                            clientWidth: z.number().nonnegative(),
-                            clientHeight: z.number().nonnegative(),
-                            innerWidth: z.number().nonnegative(),
-                            innerHeight: z.number().nonnegative(),
+                            clientWidth: z.number().positive(),
+                            clientHeight: z.number().positive(),
+                            innerWidth: z.number().positive(),
+                            innerHeight: z.number().positive(),
                             outerWidth: z.number().positive(),
                             outerHeight: z.number().positive(),
                             colorDepth: z.number().positive().optional(),
@@ -268,6 +268,12 @@ export async function getRecordSchema() {
                                 data.innerWidth <= data.outerWidth &&
                                 data.innerHeight <= data.outerHeight,
                             'Inner width and height should be less than or equal to outer width and height',
+                        )
+                        .refine(
+                            (data) =>
+                                data.clientWidth <= data.innerWidth &&
+                                data.clientHeight <= data.innerHeight,
+                            'Client width and height should be less than or equal to inner width and height',
                         )
                         .refine(
                             (data) =>

--- a/test/generator-networks-creator/record-schema.test.ts
+++ b/test/generator-networks-creator/record-schema.test.ts
@@ -1,0 +1,126 @@
+import { describe, expect, test } from 'vitest';
+
+import { getRecordSchema } from '../../packages/generator-networks-creator/src/record-schema';
+
+type ScreenOverrides = Partial<{
+    innerWidth: number;
+    innerHeight: number;
+    clientWidth: number;
+    clientHeight: number;
+}>;
+
+const buildRecord = (screen: ScreenOverrides = {}) => ({
+    requestFingerprint: {
+        headers: {
+            'user-agent':
+                'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/124.0.0.0 Safari/537.36',
+        },
+        httpVersion: '2.0',
+    },
+    browserFingerprint: {
+        webdriver: false,
+        appVersion:
+            '5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/124.0.0.0 Safari/537.36',
+        hardwareConcurrency: 8,
+        multimediaDevices: { speakers: [], micros: [], webcams: [] },
+        extraProperties: {},
+        plugins: [],
+        mimeTypes: [],
+        deviceMemory: 8,
+        oscpu: null,
+        battery: {
+            charging: true,
+            chargingTime: 1800,
+            dischargingTime: false,
+            level: 0.72,
+        },
+        platform: 'MacIntel',
+        doNotTrack: null,
+        audioCodecs: {
+            ogg: 'probably',
+            mp3: 'probably',
+            wav: 'probably',
+            m4a: 'maybe',
+            aac: 'probably',
+        },
+        videoCodecs: { ogg: 'probably', h264: 'probably', webm: 'probably' },
+        language: 'en-US',
+        languages: ['en-US'],
+        product: 'Gecko',
+        appName: 'Netscape',
+        appCodeName: 'Mozilla',
+        maxTouchPoints: 0,
+        productSub: '20030107',
+        vendor: 'Google Inc.',
+        vendorSub: '',
+        videoCard: {
+            vendor: 'Google Inc. (Apple)',
+            renderer: 'ANGLE (Apple, Apple M1, OpenGL 4.1)',
+        },
+        fonts: [],
+        screen: {
+            availTop: 25,
+            availLeft: 0,
+            pageXOffset: 0,
+            pageYOffset: 0,
+            screenX: 0,
+            hasHDR: false,
+            width: 1440,
+            height: 900,
+            availWidth: 1440,
+            availHeight: 875,
+            clientWidth: 1380,
+            clientHeight: 760,
+            innerWidth: 1380,
+            innerHeight: 760,
+            outerWidth: 1440,
+            outerHeight: 858,
+            colorDepth: 24,
+            pixelDepth: 24,
+            devicePixelRatio: 2,
+            ...screen,
+        },
+        userAgent:
+            'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/124.0.0.0 Safari/537.36',
+    },
+});
+
+describe('Record schema — viewport invariants', () => {
+    test('accepts a coherent desktop record', async () => {
+        const schema = await getRecordSchema();
+        const result = schema.safeParse(buildRecord());
+        expect(result.success).toBe(true);
+    });
+
+    test('rejects zero innerWidth / innerHeight', async () => {
+        const schema = await getRecordSchema();
+        const result = schema.safeParse(
+            buildRecord({ innerWidth: 0, innerHeight: 0 }),
+        );
+        expect(result.success).toBe(false);
+    });
+
+    test('rejects zero clientWidth / clientHeight', async () => {
+        const schema = await getRecordSchema();
+        const result = schema.safeParse(
+            buildRecord({ clientWidth: 0, clientHeight: 0 }),
+        );
+        expect(result.success).toBe(false);
+    });
+
+    test('rejects clientWidth larger than innerWidth (DOM-spec invariant)', async () => {
+        const schema = await getRecordSchema();
+        const result = schema.safeParse(
+            buildRecord({ clientWidth: 1500, innerWidth: 1380 }),
+        );
+        expect(result.success).toBe(false);
+    });
+
+    test('rejects clientHeight larger than innerHeight (DOM-spec invariant)', async () => {
+        const schema = await getRecordSchema();
+        const result = schema.safeParse(
+            buildRecord({ clientHeight: 900, innerHeight: 760 }),
+        );
+        expect(result.success).toBe(false);
+    });
+});


### PR DESCRIPTION
## Summary

Closes #6. Per the review feedback on #540 — fix at the training-record schema layer so that invalid screen viewport values (zero `innerWidth`/`innerHeight`/`clientWidth`/`clientHeight`) cannot reach the network in the first place.

## Why

The bug reporter on #6 included the actual emitted fingerprint, which contains `innerWidth: 0, innerHeight: 0, clientWidth: 0, clientHeight: 0`. These are not legal values for a real browser viewport. The training-record schema in `packages/generator-networks-creator/src/record-schema.ts` currently accepts them via `z.number().nonnegative()`, which lets the network learn them and emit them.

`packages/generator-networks-creator/generator-networks-creator.ts` calls `recordSchema.safeParse(x)` to filter records before training (see `prepareRecords`), so tightening the schema is sufficient to cut the bug off at the source.

## Changes

**`packages/generator-networks-creator/src/record-schema.ts`**

- `innerWidth`, `innerHeight`, `clientWidth`, `clientHeight`: `nonnegative()` → `positive()`. Rejects zeros at training time.
- New `.refine()`: `clientWidth <= innerWidth && clientHeight <= innerHeight`. The DOM spec guarantees `clientWidth` is the inner viewport content area minus the scrollbar gutter, so `client > inner` is structurally invalid. The existing schema enforces `availWidth <= width`, `inner <= outer`, and `pixelDepth == colorDepth`, but had no client-side counterpart; a record with e.g. `clientWidth: 1500, innerWidth: 1380` would still pass.

**`test/generator-networks-creator/record-schema.test.ts`** (new)

- Accepts a coherent desktop record.
- Rejects zero `innerWidth` / `innerHeight`.
- Rejects zero `clientWidth` / `clientHeight`.
- Rejects `clientWidth > innerWidth`.
- Rejects `clientHeight > innerHeight`.

## Validation

```
$ vitest run test/generator-networks-creator
 Test Files  2 passed (2)
      Tests  8 passed (8)

$ prettier --check packages/generator-networks-creator/src/record-schema.ts test/generator-networks-creator/record-schema.test.ts
All matched files use Prettier code style!
```

Full non-puppeteer test suite (53 tests, 7 files) also passes; puppeteer-dependent files in `test/fingerprint-injector/**` and `test/antibot-services/**` were skipped in my environment because a Chrome binary wasn't available.

/claim #6