### PR TITLE
chore: Replace calling reusable actions from `apify/workflows/...` to `apify/actions/...` [internal]

### DIFF
--- a/.github/workflows/e2e-benchmark.yml
+++ b/.github/workflows/e2e-benchmark.yml
@@ -17,7 +17,7 @@ jobs:
               with:
                   node-version: 24
 
-            - uses: apify/actions/pnpm-install@v1.0.0
+            - uses: apify/actions/pnpm-install@v1.1.0
 
             - name: Install browsers
               run: pnpm exec playwright install

--- a/.github/workflows/e2e-benchmark.yml
+++ b/.github/workflows/e2e-benchmark.yml
@@ -17,7 +17,7 @@ jobs:
               with:
                   node-version: 24
 
-            - uses: apify/actions/pnpm-install@v1.1.1
+            - uses: apify/actions/pnpm-install@v1.1.2
 
             - name: Install browsers
               run: pnpm exec playwright install

--- a/.github/workflows/e2e-benchmark.yml
+++ b/.github/workflows/e2e-benchmark.yml
@@ -17,7 +17,7 @@ jobs:
               with:
                   node-version: 24
 
-            - uses: apify/workflows/pnpm-install@main
+            - uses: apify/actions/pnpm-install@v1.0.0
 
             - name: Install browsers
               run: pnpm exec playwright install

--- a/.github/workflows/e2e-benchmark.yml
+++ b/.github/workflows/e2e-benchmark.yml
@@ -17,7 +17,7 @@ jobs:
               with:
                   node-version: 24
 
-            - uses: apify/actions/pnpm-install@v1.1.0
+            - uses: apify/actions/pnpm-install@v1.1.1
 
             - name: Install browsers
               run: pnpm exec playwright install

--- a/.github/workflows/model-updater.yml
+++ b/.github/workflows/model-updater.yml
@@ -21,7 +21,7 @@ jobs:
               with:
                   node-version: 24
 
-            - uses: apify/workflows/pnpm-install@main
+            - uses: apify/actions/pnpm-install@v1.0.0
 
             - name: Install Playwright deps
               run: pnpm exec playwright install
@@ -75,7 +75,7 @@ jobs:
               with:
                   node-version: 24
 
-            - uses: apify/workflows/pnpm-install@main
+            - uses: apify/actions/pnpm-install@v1.0.0
 
             - name: Download artifacts
               uses: actions/download-artifact@v8
@@ -114,7 +114,7 @@ jobs:
               with:
                   node-version: 24
 
-            - uses: apify/workflows/pnpm-install@main
+            - uses: apify/actions/pnpm-install@v1.0.0
 
             - uses: actions/download-artifact@v8
               with:

--- a/.github/workflows/model-updater.yml
+++ b/.github/workflows/model-updater.yml
@@ -21,7 +21,7 @@ jobs:
               with:
                   node-version: 24
 
-            - uses: apify/actions/pnpm-install@v1.1.0
+            - uses: apify/actions/pnpm-install@v1.1.1
 
             - name: Install Playwright deps
               run: pnpm exec playwright install
@@ -75,7 +75,7 @@ jobs:
               with:
                   node-version: 24
 
-            - uses: apify/actions/pnpm-install@v1.1.0
+            - uses: apify/actions/pnpm-install@v1.1.1
 
             - name: Download artifacts
               uses: actions/download-artifact@v8
@@ -114,7 +114,7 @@ jobs:
               with:
                   node-version: 24
 
-            - uses: apify/actions/pnpm-install@v1.1.0
+            - uses: apify/actions/pnpm-install@v1.1.1
 
             - uses: actions/download-artifact@v8
               with:

--- a/.github/workflows/model-updater.yml
+++ b/.github/workflows/model-updater.yml
@@ -21,7 +21,7 @@ jobs:
               with:
                   node-version: 24
 
-            - uses: apify/actions/pnpm-install@v1.1.1
+            - uses: apify/actions/pnpm-install@v1.1.2
 
             - name: Install Playwright deps
               run: pnpm exec playwright install
@@ -75,7 +75,7 @@ jobs:
               with:
                   node-version: 24
 
-            - uses: apify/actions/pnpm-install@v1.1.1
+            - uses: apify/actions/pnpm-install@v1.1.2
 
             - name: Download artifacts
               uses: actions/download-artifact@v8
@@ -114,7 +114,7 @@ jobs:
               with:
                   node-version: 24
 
-            - uses: apify/actions/pnpm-install@v1.1.1
+            - uses: apify/actions/pnpm-install@v1.1.2
 
             - uses: actions/download-artifact@v8
               with:

--- a/.github/workflows/model-updater.yml
+++ b/.github/workflows/model-updater.yml
@@ -21,7 +21,7 @@ jobs:
               with:
                   node-version: 24
 
-            - uses: apify/actions/pnpm-install@v1.0.0
+            - uses: apify/actions/pnpm-install@v1.1.0
 
             - name: Install Playwright deps
               run: pnpm exec playwright install
@@ -75,7 +75,7 @@ jobs:
               with:
                   node-version: 24
 
-            - uses: apify/actions/pnpm-install@v1.0.0
+            - uses: apify/actions/pnpm-install@v1.1.0
 
             - name: Download artifacts
               uses: actions/download-artifact@v8
@@ -114,7 +114,7 @@ jobs:
               with:
                   node-version: 24
 
-            - uses: apify/actions/pnpm-install@v1.0.0
+            - uses: apify/actions/pnpm-install@v1.1.0
 
             - uses: actions/download-artifact@v8
               with:

--- a/.github/workflows/publish-to-npm.yaml
+++ b/.github/workflows/publish-to-npm.yaml
@@ -28,7 +28,7 @@ jobs:
                   node-version: 24
                   registry-url: 'https://registry.npmjs.org/'
 
-            - uses: apify/workflows/pnpm-install@main
+            - uses: apify/actions/pnpm-install@v1.0.0
 
             - name: Turbo cache
               id: turbo-cache

--- a/.github/workflows/publish-to-npm.yaml
+++ b/.github/workflows/publish-to-npm.yaml
@@ -28,7 +28,7 @@ jobs:
                   node-version: 24
                   registry-url: 'https://registry.npmjs.org/'
 
-            - uses: apify/actions/pnpm-install@v1.1.0
+            - uses: apify/actions/pnpm-install@v1.1.1
 
             - name: Turbo cache
               id: turbo-cache

--- a/.github/workflows/publish-to-npm.yaml
+++ b/.github/workflows/publish-to-npm.yaml
@@ -28,7 +28,7 @@ jobs:
                   node-version: 24
                   registry-url: 'https://registry.npmjs.org/'
 
-            - uses: apify/actions/pnpm-install@v1.1.1
+            - uses: apify/actions/pnpm-install@v1.1.2
 
             - name: Turbo cache
               id: turbo-cache

--- a/.github/workflows/publish-to-npm.yaml
+++ b/.github/workflows/publish-to-npm.yaml
@@ -28,7 +28,7 @@ jobs:
                   node-version: 24
                   registry-url: 'https://registry.npmjs.org/'
 
-            - uses: apify/actions/pnpm-install@v1.0.0
+            - uses: apify/actions/pnpm-install@v1.1.0
 
             - name: Turbo cache
               id: turbo-cache

--- a/.github/workflows/test-and-sync.yml
+++ b/.github/workflows/test-and-sync.yml
@@ -27,7 +27,7 @@ jobs:
               with:
                   node-version: 24
 
-            - uses: apify/workflows/pnpm-install@main
+            - uses: apify/actions/pnpm-install@v1.0.0
 
             - run: pnpm lint
 
@@ -48,7 +48,7 @@ jobs:
               with:
                   node-version: ${{ matrix.node-version }}
 
-            - uses: apify/workflows/pnpm-install@main
+            - uses: apify/actions/pnpm-install@v1.0.0
 
             - name: Install Playwright deps
               run: pnpm exec playwright install --with-deps

--- a/.github/workflows/test-and-sync.yml
+++ b/.github/workflows/test-and-sync.yml
@@ -27,7 +27,7 @@ jobs:
               with:
                   node-version: 24
 
-            - uses: apify/actions/pnpm-install@v1.1.0
+            - uses: apify/actions/pnpm-install@v1.1.1
 
             - run: pnpm lint
 
@@ -48,7 +48,7 @@ jobs:
               with:
                   node-version: ${{ matrix.node-version }}
 
-            - uses: apify/actions/pnpm-install@v1.1.0
+            - uses: apify/actions/pnpm-install@v1.1.1
 
             - name: Install Playwright deps
               run: pnpm exec playwright install --with-deps

--- a/.github/workflows/test-and-sync.yml
+++ b/.github/workflows/test-and-sync.yml
@@ -27,7 +27,7 @@ jobs:
               with:
                   node-version: 24
 
-            - uses: apify/actions/pnpm-install@v1.1.1
+            - uses: apify/actions/pnpm-install@v1.1.2
 
             - run: pnpm lint
 
@@ -48,7 +48,7 @@ jobs:
               with:
                   node-version: ${{ matrix.node-version }}
 
-            - uses: apify/actions/pnpm-install@v1.1.1
+            - uses: apify/actions/pnpm-install@v1.1.2
 
             - name: Install Playwright deps
               run: pnpm exec playwright install --with-deps

--- a/.github/workflows/test-and-sync.yml
+++ b/.github/workflows/test-and-sync.yml
@@ -27,7 +27,7 @@ jobs:
               with:
                   node-version: 24
 
-            - uses: apify/actions/pnpm-install@v1.0.0
+            - uses: apify/actions/pnpm-install@v1.1.0
 
             - run: pnpm lint
 
@@ -48,7 +48,7 @@ jobs:
               with:
                   node-version: ${{ matrix.node-version }}
 
-            - uses: apify/actions/pnpm-install@v1.0.0
+            - uses: apify/actions/pnpm-install@v1.1.0
 
             - name: Install Playwright deps
               run: pnpm exec playwright install --with-deps


### PR DESCRIPTION
It was confusing that we have our custom GitHub actions in a repository called `workflows`. I've moved them to a new repository called `actions`, and this PR replaces the references to the actions to point to the new repository.

There are no functional changes, the actions just moved.