### PR TITLE
fix: avoid read-only srcdoc assignment in iframe hook

### DIFF
--- a/packages/fingerprint-injector/src/utils.js
+++ b/packages/fingerprint-injector/src/utils.js
@@ -710,13 +710,14 @@ function fixIframeContentWindow() {
                 },
                 set(newValue) {
                     addContentWindowProxy(this);
+                    const srcdoc = `${newValue}`;
                     // Reset property, the hook is only needed once
                     Object.defineProperty(iframe, 'srcdoc', {
                         configurable: false,
                         writable: false,
-                        value: _srcdoc,
+                        value: srcdoc,
                     });
-                    _iframe.srcdoc = newValue;
+                    _iframe.setAttribute('srcdoc', srcdoc);
                 },
             });
             return iframe;

--- a/test/fingerprint-injector/fingerprint-injector.test.ts
+++ b/test/fingerprint-injector/fingerprint-injector.test.ts
@@ -91,6 +91,48 @@ describe('FingerprintInjector', () => {
         // eslint-disable-next-line dot-notation
         expect(fpInjector['utilsJs']).toBeTruthy();
     });
+
+    test('should preserve iframe srcdoc after installing contentWindow fix', async () => {
+        const browser = await chromium.launch();
+
+        try {
+            const page = await browser.newPage();
+            // eslint-disable-next-line dot-notation
+            const utilsJs = fpInjector['utilsJs'];
+            const result = await page.evaluate((utils) => {
+                const script = document.createElement('script');
+                script.textContent = `${utils}\nfixIframeContentWindow();`;
+                document.documentElement.append(script);
+                script.remove();
+
+                const iframe = document.createElement('iframe');
+                (document.body ?? document.documentElement).append(iframe);
+
+                const srcdoc = '<p id="loaded">loaded</p>';
+                let errorMessage: string | null = null;
+
+                try {
+                    iframe.srcdoc = srcdoc;
+                } catch (error) {
+                    errorMessage =
+                        error instanceof Error ? error.message : String(error);
+                }
+
+                return {
+                    attribute: iframe.getAttribute('srcdoc'),
+                    errorMessage,
+                    property: iframe.srcdoc,
+                };
+            }, utilsJs);
+
+            expect(result.errorMessage).toBeNull();
+            expect(result.attribute).toBe('<p id="loaded">loaded</p>');
+            expect(result.property).toBe('<p id="loaded">loaded</p>');
+        } finally {
+            await browser.close();
+        }
+    });
+
     // @ts-expect-error test only
     describe.each(cases)('%s', (frameworkName, testCases) => {
         // @ts-expect-error test only


### PR DESCRIPTION
## Summary

Fixes the iframe `srcdoc` hook in `fixIframeContentWindow()` so assigning `iframe.srcdoc` preserves the assigned value instead of leaving the iframe without `srcdoc` content.

## What changed

- Added a focused Playwright/Vitest regression test that installs the injected `contentWindow` fix, assigns `iframe.srcdoc`, and checks both the DOM attribute and property value.
- Updated the one-shot `srcdoc` setter to store the assigned string on the final descriptor and write it with `setAttribute()` instead of assigning to the now non-writable property.

## Why

The previous hook reset `srcdoc` as a non-writable own property with the original value, then immediately assigned through `_iframe.srcdoc`. In Chromium this left the `srcdoc` attribute unset, and in strict contexts it can throw `Cannot assign to read only property 'srcdoc'` as described in #546.

## Testing

- `pnpm install --frozen-lockfile`
- `pnpm exec playwright install chromium`
- `pnpm exec vitest run test/fingerprint-injector/fingerprint-injector.test.ts -t "srcdoc"` (failed before the fix: `srcdoc` attribute was `null`)
- `pnpm exec vitest run test/fingerprint-injector/fingerprint-injector.test.ts -t "srcdoc"`
- `pnpm build`
- `pnpm lint` (passes with existing `no-console` warnings)
- `git diff --check`

Fixes #546

Note: I used Codex to inspect the code path and draft the focused regression test, then reviewed the final diff and ran the listed verification commands locally.
