### PR TITLE
fix(fingerprint-generator): guard generated viewport dimensions

### DIFF
--- a/packages/fingerprint-generator/src/fingerprint-generator.ts
+++ b/packages/fingerprint-generator/src/fingerprint-generator.ts
@@ -244,6 +244,13 @@ export class FingerprintGenerator extends HeaderGenerator {
 
             if (!fingerprint.screen) continue; // fix? sometimes, fingerprints are generated 90% empty/null. This is just a workaround.
 
+            fingerprint.screen = this.normalizeScreenFingerprint(
+                fingerprint.screen,
+            );
+
+            if (!this.isPlausibleScreenFingerprint(fingerprint.screen))
+                continue; // fix? sometimes, fingerprints are generated 90% empty/null. This is just a workaround.
+
             // Manually add the set of accepted languages required by the input
             const acceptLanguageHeaderValue =
                 'Accept-Language' in headers
@@ -351,5 +358,52 @@ export class FingerprintGenerator extends HeaderGenerator {
             multimediaDevices,
             fonts,
         } as Fingerprint;
+    }
+
+    private normalizeScreenFingerprint(
+        screen: ScreenFingerprint,
+    ): ScreenFingerprint {
+        const outerWidth = screen.outerWidth || screen.width;
+        const outerHeight = screen.outerHeight || screen.height;
+        const innerWidth =
+            screen.innerWidth || Math.min(screen.width, outerWidth);
+        const innerHeight =
+            screen.innerHeight || Math.min(screen.availHeight, outerHeight);
+
+        return {
+            ...screen,
+            outerWidth,
+            outerHeight,
+            innerWidth,
+            innerHeight,
+            clientWidth: screen.clientWidth || innerWidth,
+            clientHeight: screen.clientHeight || innerHeight,
+        };
+    }
+
+    private isPlausibleScreenFingerprint(screen: Partial<ScreenFingerprint>) {
+        const positiveViewportFields = [
+            screen.clientWidth,
+            screen.clientHeight,
+            screen.innerWidth,
+            screen.innerHeight,
+            screen.outerWidth,
+            screen.outerHeight,
+        ];
+
+        if (
+            positiveViewportFields.some(
+                (value) => typeof value !== 'number' || value <= 0,
+            )
+        ) {
+            return false;
+        }
+
+        return (
+            screen.clientWidth! <= screen.innerWidth! &&
+            screen.clientHeight! <= screen.innerHeight! &&
+            screen.innerWidth! <= screen.outerWidth! &&
+            screen.innerHeight! <= screen.outerHeight!
+        );
     }
 }

--- a/test/fingerprint-generator/generation.test.ts
+++ b/test/fingerprint-generator/generation.test.ts
@@ -84,6 +84,73 @@ describe('Generation tests', () => {
             expect(field).toBeDefined();
         }
     });
+
+    test('rejects generated fingerprints with impossible viewport dimensions', () => {
+        const {
+            fingerprint: { screen },
+        } = fingerprintGenerator.getFingerprint({
+            browsers: [{ name: 'chrome', minVersion: 100, maxVersion: 100 }],
+            devices: ['desktop'],
+            operatingSystems: ['macos'],
+        });
+        const isPlausibleScreenFingerprint = (
+            fingerprintGenerator as any
+        ).isPlausibleScreenFingerprint.bind(fingerprintGenerator);
+
+        expect(isPlausibleScreenFingerprint(screen)).toBe(true);
+        expect(
+            isPlausibleScreenFingerprint({
+                ...screen,
+                clientWidth: 0,
+            }),
+        ).toBe(false);
+        expect(
+            isPlausibleScreenFingerprint({
+                ...screen,
+                innerHeight: 0,
+            }),
+        ).toBe(false);
+        expect(
+            isPlausibleScreenFingerprint({
+                ...screen,
+                clientWidth: screen.innerWidth + 1,
+            }),
+        ).toBe(false);
+        expect(
+            isPlausibleScreenFingerprint({
+                ...screen,
+                innerHeight: screen.outerHeight + 1,
+            }),
+        ).toBe(false);
+    });
+
+    test('normalizes zero viewport dimensions from generated screen data', () => {
+        const {
+            fingerprint: { screen },
+        } = fingerprintGenerator.getFingerprint({
+            browsers: [{ name: 'chrome', minVersion: 100, maxVersion: 100 }],
+            devices: ['desktop'],
+            operatingSystems: ['macos'],
+        });
+        const normalizeScreenFingerprint = (
+            fingerprintGenerator as any
+        ).normalizeScreenFingerprint.bind(fingerprintGenerator);
+
+        const normalizedScreen = normalizeScreenFingerprint({
+            ...screen,
+            clientWidth: 0,
+            clientHeight: 0,
+            innerWidth: 0,
+            innerHeight: 0,
+        });
+
+        expect(normalizedScreen.innerWidth).toBeGreaterThan(0);
+        expect(normalizedScreen.innerHeight).toBeGreaterThan(0);
+        expect(normalizedScreen.clientWidth).toBe(normalizedScreen.innerWidth);
+        expect(normalizedScreen.clientHeight).toBe(
+            normalizedScreen.innerHeight,
+        );
+    });
 });
 
 describe('Generate fingerprints with basic constraints', () => {


### PR DESCRIPTION
Fixes #6.

The generated fingerprint network can still return screen records with zero viewport fields such as `innerWidth`, `innerHeight`, `clientWidth`, and `clientHeight`. Those values are easy to flag because they do not match a real browser viewport.

This change adds a small guard at fingerprint generation time:

- normalize zero viewport fields from the surrounding screen dimensions when the generated record is otherwise usable
- skip generated screens that still violate basic `client <= inner <= outer` viewport invariants
- cover the Chrome 100/macOS generation path and the zero-viewport normalization case with regression tests

This complements #544. That PR tightens future training records; this one protects the runtime generator from the current published network output as well.

Validation:

- `corepack pnpm vitest run test/fingerprint-generator/generation.test.ts --reporter verbose`
- `corepack pnpm exec prettier packages/fingerprint-generator/src/fingerprint-generator.ts test/fingerprint-generator/generation.test.ts --check`
- `git diff --check`
- Git Bash: `npm exec --yes pnpm@10.33.4 -- build`

Note: full `pnpm lint` is not clean on the current checkout because repo-wide Prettier reports existing formatting differences in untouched files. The two changed files pass Prettier directly.

@algora-pbc /claim #6