### PR TITLE
fix(generator-networks-creator): repair zero viewport dimensions before training

### DIFF
--- a/packages/generator-networks-creator/src/generator-networks-creator.ts
+++ b/packages/generator-networks-creator/src/generator-networks-creator.ts
@@ -3,6 +3,10 @@ import path from 'path';
 
 import { BayesianNetwork } from 'generative-bayesian-network';
 import { getRecordSchema } from './record-schema';
+import {
+    hasZeroViewportDimensions,
+    normalizeFingerprintRecordScreenViewport,
+} from './screen-viewport';
 
 const browserHttpNodeName = '*BROWSER_HTTP';
 const httpVersionNodeName = '*HTTP_VERSION';
@@ -27,8 +31,12 @@ async function prepareRecords(
     preprocessingType: string,
 ): Promise<Record<string, any>[]> {
     const recordSchema = await getRecordSchema();
+    const sourceRecords =
+        preprocessingType === 'fingerprints'
+            ? records.map(normalizeFingerprintRecordScreenViewport)
+            : records;
 
-    const cleanedRecords = records
+    const cleanedRecords = sourceRecords
         .map((x) => recordSchema.safeParse(x))
         .filter((record) => record.success)
         .map((record) => record.data);
@@ -37,7 +45,7 @@ async function prepareRecords(
         `Found ${cleanedRecords.length}/${records.length} valid records.`,
     );
 
-    const deconstructedRecords = cleanedRecords
+    let deconstructedRecords = cleanedRecords
         .map((record) => {
             if (preprocessingType === 'headers') {
                 const { httpVersion, headers } = record.requestFingerprint;
@@ -49,6 +57,22 @@ async function prepareRecords(
             }
         })
         .filter((x) => x);
+
+    if (preprocessingType === 'fingerprints') {
+        const recordsWithZeroViewport = deconstructedRecords.filter((record) =>
+            hasZeroViewportDimensions(record.screen),
+        );
+
+        if (recordsWithZeroViewport.length > 0) {
+            console.log(
+                `Dropped ${recordsWithZeroViewport.length} fingerprint records with unrepaired zero viewport dimensions.`,
+            );
+        }
+
+        deconstructedRecords = deconstructedRecords.filter(
+            (record) => !hasZeroViewportDimensions(record.screen),
+        );
+    }
 
     const attributes = new Set<keyof (typeof deconstructedRecords)[number]>(
         deconstructedRecords.flatMap((record) =>

--- a/packages/generator-networks-creator/src/screen-viewport.ts
+++ b/packages/generator-networks-creator/src/screen-viewport.ts
@@ -1,0 +1,93 @@
+const VIEWPORT_DIMENSIONS = [
+    'innerWidth',
+    'innerHeight',
+    'clientWidth',
+    'clientHeight',
+] as const;
+
+type ScreenRecord = Record<string, unknown>;
+
+function isPositiveNumber(value: unknown): value is number {
+    return typeof value === 'number' && Number.isFinite(value) && value > 0;
+}
+
+function minPositiveNumber(...values: unknown[]): number | undefined {
+    const positiveValues = values.filter(isPositiveNumber);
+    return positiveValues.length === 0
+        ? undefined
+        : Math.min(...positiveValues);
+}
+
+export function normalizeCollectedScreenViewport(screen: unknown): unknown {
+    if (!screen || typeof screen !== 'object') return screen;
+
+    const normalized = { ...(screen as ScreenRecord) };
+    const screenWidth = normalized.width;
+    const screenHeight = normalized.height;
+    const availWidth = normalized.availWidth;
+    const availHeight = normalized.availHeight;
+    const outerWidth = isPositiveNumber(normalized.outerWidth)
+        ? normalized.outerWidth
+        : minPositiveNumber(screenWidth, availWidth);
+    const outerHeight = isPositiveNumber(normalized.outerHeight)
+        ? normalized.outerHeight
+        : minPositiveNumber(screenHeight, availHeight);
+
+    if (!isPositiveNumber(normalized.innerWidth)) {
+        const innerWidth = minPositiveNumber(
+            normalized.width,
+            normalized.availWidth,
+            outerWidth,
+        );
+        if (innerWidth !== undefined) normalized.innerWidth = innerWidth;
+    }
+
+    if (!isPositiveNumber(normalized.innerHeight)) {
+        const innerHeight = minPositiveNumber(
+            normalized.height,
+            normalized.availHeight,
+            outerHeight,
+        );
+        if (innerHeight !== undefined) normalized.innerHeight = innerHeight;
+    }
+
+    if (
+        !isPositiveNumber(normalized.clientWidth) &&
+        isPositiveNumber(normalized.innerWidth)
+    ) {
+        normalized.clientWidth = normalized.innerWidth;
+    }
+
+    if (
+        !isPositiveNumber(normalized.clientHeight) &&
+        isPositiveNumber(normalized.innerHeight)
+    ) {
+        normalized.clientHeight = normalized.innerHeight;
+    }
+
+    return normalized;
+}
+
+export function normalizeFingerprintRecordScreenViewport(
+    record: Record<string, any>,
+) {
+    const screen = record.browserFingerprint?.screen;
+    if (!screen || typeof screen !== 'object') return record;
+
+    return {
+        ...record,
+        browserFingerprint: {
+            ...record.browserFingerprint,
+            screen: normalizeCollectedScreenViewport(screen),
+        },
+    };
+}
+
+export function hasZeroViewportDimensions(screen: unknown): boolean {
+    if (!screen || typeof screen !== 'object') return false;
+
+    const screenRecord = screen as ScreenRecord;
+    return VIEWPORT_DIMENSIONS.some(
+        (dimension) => screenRecord[dimension] === 0,
+    );
+}

--- a/test/generator-networks-creator/screen-viewport.test.ts
+++ b/test/generator-networks-creator/screen-viewport.test.ts
@@ -1,0 +1,86 @@
+import { describe, expect, test } from 'vitest';
+
+import {
+    hasZeroViewportDimensions,
+    normalizeCollectedScreenViewport,
+    normalizeFingerprintRecordScreenViewport,
+} from '../../packages/generator-networks-creator/src/screen-viewport';
+
+describe('Collected screen viewport normalization', () => {
+    test('repairs zero viewport dimensions from surrounding screen values', () => {
+        const screen = normalizeCollectedScreenViewport({
+            width: 1440,
+            height: 900,
+            availWidth: 1440,
+            availHeight: 875,
+            outerWidth: 1284,
+            outerHeight: 858,
+            innerWidth: 0,
+            innerHeight: 0,
+            clientWidth: 0,
+            clientHeight: 0,
+        });
+
+        expect(screen).toMatchObject({
+            innerWidth: 1284,
+            innerHeight: 858,
+            clientWidth: 1284,
+            clientHeight: 858,
+        });
+        expect(hasZeroViewportDimensions(screen)).toBe(false);
+    });
+
+    test('keeps collected positive viewport dimensions unchanged', () => {
+        const screen = normalizeCollectedScreenViewport({
+            width: 1440,
+            height: 900,
+            availWidth: 1440,
+            availHeight: 875,
+            outerWidth: 1284,
+            outerHeight: 858,
+            innerWidth: 1284,
+            innerHeight: 769,
+            clientWidth: 1269,
+            clientHeight: 754,
+        });
+
+        expect(screen).toMatchObject({
+            innerWidth: 1284,
+            innerHeight: 769,
+            clientWidth: 1269,
+            clientHeight: 754,
+        });
+    });
+
+    test('repairs only the browser fingerprint screen on a dataset record', () => {
+        const requestFingerprint = {
+            headers: { 'user-agent': 'example' },
+            httpVersion: '2',
+        };
+        const record = normalizeFingerprintRecordScreenViewport({
+            requestFingerprint,
+            browserFingerprint: {
+                screen: {
+                    width: 1440,
+                    height: 900,
+                    availWidth: 1440,
+                    availHeight: 875,
+                    outerWidth: 1284,
+                    outerHeight: 858,
+                    innerWidth: 0,
+                    innerHeight: 0,
+                    clientWidth: 0,
+                    clientHeight: 0,
+                },
+            },
+        });
+
+        expect(record.requestFingerprint).toBe(requestFingerprint);
+        expect(record.browserFingerprint.screen).toMatchObject({
+            innerWidth: 1284,
+            innerHeight: 858,
+            clientWidth: 1284,
+            clientHeight: 858,
+        });
+    });
+});


### PR DESCRIPTION
Addresses #6.

@algora-pbc /claim #6

## Summary

This follows the review feedback on #544 and #549 by keeping the fix out of runtime generation and out of the zod schema rejection path.

The patch repairs zero viewport dimensions in collected fingerprint records before they are deconstructed into the fingerprint training dataset:

- infer zero `innerWidth` / `innerHeight` from the same record's screen, available screen, and outer window dimensions
- infer zero `clientWidth` / `clientHeight` from the repaired inner viewport dimensions
- preserve already collected positive viewport/client values unchanged
- drop only fingerprint records that still contain unrepaired zero viewport dimensions after the repair step

That prevents future fingerprint networks from learning the `innerWidth: 0`, `innerHeight: 0`, `clientWidth: 0`, `clientHeight: 0` shape reported in #6 without rejecting the bulk of the existing corpus.

## Validation

- `pnpm exec vitest run test/generator-networks-creator/screen-viewport.test.ts test/generator-networks-creator/generator-networks-creator.test.ts`
- `pnpm exec tsc --noEmit -p tsconfig.json`
- `pnpm exec prettier --check packages/generator-networks-creator/src/generator-networks-creator.ts packages/generator-networks-creator/src/screen-viewport.ts test/generator-networks-creator/screen-viewport.test.ts`
- `pnpm --filter generator-networks-creator compile`
- `pnpm --filter generative-bayesian-network compile`
- `git diff --check`