### PR TITLE
chore: bump `adm-zip` to `^0.6.0`

### DIFF
--- a/packages/generative-bayesian-network/package.json
+++ b/packages/generative-bayesian-network/package.json
@@ -18,7 +18,7 @@
         "url": "https://github.com/apify/fingerprint-suite/issues"
     },
     "dependencies": {
-        "adm-zip": "^0.5.9",
+        "adm-zip": "^0.6.0",
         "tslib": "^2.4.0"
     },
     "description": "An fast implementation of a generative bayesian network.",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -138,8 +138,8 @@ importers:
   packages/generative-bayesian-network:
     dependencies:
       adm-zip:
-        specifier: ^0.5.9
-        version: 0.5.17
+        specifier: ^0.6.0
+        version: 0.6.0
       tslib:
         specifier: ^2.4.0
         version: 2.8.1
@@ -813,9 +813,9 @@ packages:
     engines: {node: '>=0.4.0'}
     hasBin: true
 
-  adm-zip@0.5.17:
-    resolution: {integrity: sha512-+Ut8d9LLqwEvHHJl1+PIHqoyDxFgVN847JTVM3Izi3xHDWPE4UtzzXysMZQs64DMcrJfBeS/uoEP4AD3HQHnQQ==}
-    engines: {node: '>=12.0'}
+  adm-zip@0.6.0:
+    resolution: {integrity: sha512-XleryMhbuksdKtofnWZ9Sk+4CUTbms4Mb/EU32SZwToAyZ5RgVos/ki8n+yr0LWHOGKuakbXTuuYNHLQjhddgg==}
+    engines: {node: '>=14.0'}
 
   agent-base@7.1.4:
     resolution: {integrity: sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ==}
@@ -3299,7 +3299,7 @@ snapshots:
 
   acorn@8.16.0: {}
 
-  adm-zip@0.5.17: {}
+  adm-zip@0.6.0: {}
 
   agent-base@7.1.4: {}
 


### PR DESCRIPTION
Bumps adm-zip in generative-bayesian-network; verified builds, ESM/CJS output, and Node >=16 compatibility unaffected.