### PR TITLE
chore(ci): add permissions for CI workflows

### DIFF
--- a/.github/workflows/browserforge-compat-test.yml
+++ b/.github/workflows/browserforge-compat-test.yml
@@ -3,6 +3,8 @@ name: Test Browserforge compatibility
 on:
     workflow_call:
 
+permissions: {}
+
 jobs:
     test:
         runs-on: ubuntu-22.04

--- a/.github/workflows/check-pr-title.yml
+++ b/.github/workflows/check-pr-title.yml
@@ -4,6 +4,8 @@ on:
     pull_request_target:
         types: [opened, edited, synchronize]
 
+permissions: {}
+
 jobs:
     check_pr_title:
         name: 'Check PR title'

--- a/.github/workflows/e2e-benchmark.yml
+++ b/.github/workflows/e2e-benchmark.yml
@@ -4,6 +4,9 @@ on:
     # Triggers the workflow every Monday at 5am
     workflow_dispatch:
 
+permissions:
+    contents: write
+
 jobs:
     run_benchmark:
         runs-on: ubuntu-22.04

--- a/.github/workflows/model-updater.yml
+++ b/.github/workflows/model-updater.yml
@@ -6,6 +6,9 @@ on:
         - cron: '0 0 1 * *'
     workflow_dispatch:
 
+permissions:
+    contents: read
+
 jobs:
     build_model:
         runs-on: ubuntu-22.04
@@ -104,6 +107,8 @@ jobs:
         name: Commit and push new model
         needs: [build_model, test_model_js, test_model_py]
         runs-on: ubuntu-22.04
+        permissions:
+            contents: write
         steps:
             - uses: actions/checkout@v6
               with:

--- a/.github/workflows/test-and-sync.yml
+++ b/.github/workflows/test-and-sync.yml
@@ -11,6 +11,9 @@ on:
     workflow_call:
     workflow_dispatch:
 
+permissions:
+    contents: read
+
 env:
     APIFY_HTTPBIN_TOKEN: ${{ secrets.APIFY_HTTPBIN_TOKEN }}
 


### PR DESCRIPTION
Adds explicit `permissions` blocks to fix code-scanning `missing-workflow-permissions` alerts.