### PR TITLE
chore(ci): publish packages in dependency order and fail on publish errors

### DIFF
--- a/scripts/publish.sh
+++ b/scripts/publish.sh
@@ -1,17 +1,16 @@
 #!/bin/bash
+set -e
 
 SCRIPT_DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
 PACKAGES_TO_PUBLISH=( "generative-bayesian-network" "header-generator" "fingerprint-generator" "fingerprint-injector" )
 
-for FOLDER in $SCRIPT_DIR/../packages/*; do
+for PACKAGE_NAME in "${PACKAGES_TO_PUBLISH[@]}"; do
+  FOLDER="$SCRIPT_DIR/../packages/$PACKAGE_NAME"
   if [[ -d $FOLDER ]]; then
-    PACKAGE_NAME=$(basename $FOLDER)
-    if [[ " ${PACKAGES_TO_PUBLISH[@]} " =~ " ${PACKAGE_NAME} " ]]; then
-      echo "Publishing $PACKAGE_NAME"
-      cd $FOLDER/dist
-      pnpm publish --no-git-checks
+    echo "Publishing $PACKAGE_NAME"
+    cd $FOLDER/dist
+    pnpm publish --no-git-checks
 
-      cd $SCRIPT_DIR/../
-    fi
+    cd $SCRIPT_DIR/../
   fi
 done


### PR DESCRIPTION
publish.sh globbed packages/* in alphabetical order and ignored pnpm's exit code, so dependent packages were published before their workspace deps and the failures didn't fail the job. Now it iterates PACKAGES_TO_PUBLISH in declared order and runs under set -e. Closes #561.