### PR TITLE
chore: gate automated model updates and fix model quality bugs

### DIFF
--- a/.github/workflows/model-release.yml
+++ b/.github/workflows/model-release.yml
@@ -1,0 +1,62 @@
+name: Model release
+
+# Second half of the automated model update. `model-updater.yml` builds, verifies and
+# proposes a model as a `model-update/*` pull request; this workflow tags and releases it
+# once a human merges that PR. Creating the release is what triggers publish-to-npm.yaml,
+# so the publish is gated on the merge.
+#
+# Split out as part of the fix for https://github.com/apify/fingerprint-suite/issues/564,
+# where the updater pushed, tagged and released a degraded model unattended.
+
+on:
+    pull_request:
+        types: [closed]
+        branches: [master]
+
+permissions:
+    contents: read
+
+jobs:
+    release:
+        name: Tag and release merged model
+        if: >-
+            github.event.pull_request.merged == true &&
+            startsWith(github.event.pull_request.head.ref, 'model-update/')
+        runs-on: ubuntu-22.04
+        permissions:
+            contents: write
+        steps:
+            - uses: actions/checkout@v6
+              with:
+                  ref: master
+                  token: ${{ secrets.APIFY_SERVICE_ACCOUNT_GITHUB_TOKEN }}
+
+            - name: Read merged version
+              id: version
+              run: |
+                  set -euo pipefail
+                  VERSION=$(node -p "require('./package.json').version")
+                  echo "version=${VERSION}" >> $GITHUB_OUTPUT
+                  echo "Releasing v${VERSION}"
+
+            - name: Create tag and release
+              env:
+                  GH_TOKEN: ${{ secrets.APIFY_SERVICE_ACCOUNT_GITHUB_TOKEN }}
+                  VERSION: ${{ steps.version.outputs.version }}
+                  PR_NUMBER: ${{ github.event.pull_request.number }}
+              run: |
+                  set -euo pipefail
+
+                  if gh release view "v${VERSION}" >/dev/null 2>&1; then
+                      echo "Release v${VERSION} already exists; nothing to do."
+                      exit 0
+                  fi
+
+                  gh release create "v${VERSION}" \
+                      --target master \
+                      --title "v${VERSION}" \
+                      --notes "This is an automated release of the model used by the \`fingerprint-suite\`.
+
+                  The only difference between this release and the previous one is the model used to generate fingerprints.
+
+                  Reviewed and merged in #${PR_NUMBER}."

--- a/.github/workflows/model-updater.yml
+++ b/.github/workflows/model-updater.yml
@@ -47,10 +47,23 @@ jobs:
               run: |
                   xvfb-run -- node ./packages/header-order-collector/collector.js | tee ./packages/header-generator/src/data_files/headers-order.json
 
-            - name: Generate model
+            # Keeps the freshness check in `pnpm verifyModel` meaningful: it compares the
+            # generated model against the newest browser versions browserslist knows
+            # about, which is only useful if caniuse-lite is current.
+            - name: Refresh browser version data
+              run: pnpm dlx update-browserslist-db@latest
+
+            # `pnpm buildNetwork` ends in `pnpm verifyModel`, which fails the job if the
+            # generated model is stale, regressed, or implausible. See
+            # https://github.com/apify/fingerprint-suite/issues/564 for why.
+            - name: Generate and verify model
               run: pnpm buildNetwork
               env:
                   APIFY_FINGERPRINT_DATASET_ID: ${{ secrets.APIFY_FINGERPRINT_DATASET_ID }}
+
+            - name: Publish model summary
+              if: always()
+              run: cat model-summary.md >> $GITHUB_STEP_SUMMARY || true
 
             - name: Upload models as artifacts
               uses: actions/upload-artifact@v7
@@ -64,6 +77,7 @@ jobs:
                       ./packages/fingerprint-generator/src/data_files/fingerprint-network-definition.zip
                       ./package.json
                       ./pnpm-lock.yaml
+                      ./model-summary.md
 
     test_model_js:
         runs-on: ubuntu-22.04
@@ -103,12 +117,17 @@ jobs:
         needs: build_model
         uses: ./.github/workflows/browserforge-compat-test.yml
 
-    commit_model:
-        name: Commit and push new model
+    # Opens a pull request instead of pushing to master. Tagging and the GitHub release
+    # (which is what triggers the npm/PyPI publish) happen only after a human merges it
+    # — see .github/workflows/model-release.yml. Before #564 this job pushed, tagged and
+    # released in one step, so a bad model reached npm with nobody in the loop.
+    open_model_pr:
+        name: Open model update PR
         needs: [build_model, test_model_js, test_model_py]
         runs-on: ubuntu-22.04
         permissions:
             contents: write
+            pull-requests: write
         steps:
             - uses: actions/checkout@v6
               with:
@@ -151,26 +170,60 @@ jobs:
                   # Update changelog
                   sed -i "5i## $(uv version --short) - ($(date "+%Y-%m-%d"))\n\n- Updated data. Same as npm package \`fingerprint-generator\` version \`$version\`\n" CHANGELOG.md
 
-            - name: Push new model
-              uses: stefanzweifel/git-auto-commit-action@v7
-              with:
-                  commit_message: '[auto] fingerprint/header model update'
-                  branch: master
-                  tagging_message: 'v${{ steps.bump_version.outputs.version }}'
-
-                  file_pattern: './packages/ ./package.json ./pnpm-lock.yaml ./apify_fingerprint_datapoints/CHANGELOG.md ./pyproject.toml'
-
-                  commit_user_name: 'modelmaker[bot] ⚒️'
-                  commit_user_email: modelmaker[bot]@users.noreply.github.com
-
-            - name: Create release
-              uses: actions/create-release@v1
+            # The branch name prefix is the contract with model-release.yml, which tags
+            # and releases only when a `model-update/*` branch is merged.
+            - name: Commit new model to a branch
+              id: commit
               env:
-                  GITHUB_TOKEN: ${{ secrets.APIFY_SERVICE_ACCOUNT_GITHUB_TOKEN }}
-              with:
-                  tag_name: 'v${{ steps.bump_version.outputs.version }}'
-                  release_name: 'v${{ steps.bump_version.outputs.version }}'
-                  body: |
-                      This is an automated release of the model used by the `fingerprint-suite`.
+                  VERSION: ${{ steps.bump_version.outputs.version }}
+              run: |
+                  set -euo pipefail
 
-                      The only difference between this release and the previous one is the model used to generate fingerprints.
+                  BRANCH="model-update/v${VERSION}"
+                  echo "branch=${BRANCH}" >> $GITHUB_OUTPUT
+
+                  git config user.name 'modelmaker[bot] ⚒️'
+                  git config user.email 'modelmaker[bot]@users.noreply.github.com'
+
+                  git checkout -b "${BRANCH}"
+                  git add ./packages ./package.json ./pnpm-lock.yaml \
+                      ./apify_fingerprint_datapoints/CHANGELOG.md ./pyproject.toml
+
+                  if git diff --cached --quiet; then
+                      echo "No model changes to propose."
+                      echo "changed=false" >> $GITHUB_OUTPUT
+                      exit 0
+                  fi
+
+                  git commit -m '[auto] fingerprint/header model update'
+                  git push --force origin "${BRANCH}"
+                  echo "changed=true" >> $GITHUB_OUTPUT
+
+            - name: Open pull request
+              if: steps.commit.outputs.changed == 'true'
+              env:
+                  GH_TOKEN: ${{ secrets.APIFY_SERVICE_ACCOUNT_GITHUB_TOKEN }}
+                  BRANCH: ${{ steps.commit.outputs.branch }}
+                  VERSION: ${{ steps.bump_version.outputs.version }}
+              run: |
+                  set -euo pipefail
+
+                  {
+                      echo "Automated update of the fingerprint/header model, for release as \`v${VERSION}\`."
+                      echo
+                      echo "Automated checks that already ran: model verification (\`pnpm verifyModel\`), the JS test suite, and the browserforge compatibility suite."
+                      echo
+                      if [ -f model-summary.md ]; then cat model-summary.md; echo; fi
+                      echo "### Before merging"
+                      echo
+                      echo "Merging this PR tags \`v${VERSION}\` and publishes to npm and PyPI. Please sanity-check the coverage table above — in particular that no browser's newest version moved backwards."
+                  } > pr-body.md
+
+                  # Reuse the existing PR if this workflow already ran for this version.
+                  if ! gh pr edit "${BRANCH}" --title "[auto] fingerprint/header model update (v${VERSION})" --body-file pr-body.md 2>/dev/null; then
+                      gh pr create \
+                          --base master \
+                          --head "${BRANCH}" \
+                          --title "[auto] fingerprint/header model update (v${VERSION})" \
+                          --body-file pr-body.md
+                  fi

--- a/.gitignore
+++ b/.gitignore
@@ -24,3 +24,9 @@ docs/typedefs
 .docusaurus
 tsconfig.tsbuildinfo
 .turbo
+
+# Raw fingerprint dataset downloaded by scripts/netgen.sh. Hundreds of MB, and
+# never belongs in the repository.
+scripts/dataset.json
+# Model build report written by scripts/verify-model.ts.
+model-summary.md

--- a/package.json
+++ b/package.json
@@ -38,7 +38,8 @@
         "test": "vitest",
         "lint": "eslint && prettier . --check",
         "lint:fix": "eslint --fix && prettier . --write",
-        "buildNetwork": "turbo run build && ./scripts/netgen.sh && turbo run build",
+        "buildNetwork": "turbo run build && ./scripts/netgen.sh && turbo run build && pnpm verifyModel",
+        "verifyModel": "ts-node ./scripts/verify-model.ts",
         "benchmark": "ts-node ./test/antibot-services/live-testing/cloudflare.ts"
     },
     "devDependencies": {

--- a/packages/generator-networks-creator/src/generator-networks-creator.ts
+++ b/packages/generator-networks-creator/src/generator-networks-creator.ts
@@ -22,20 +22,75 @@ const STRINGIFIED_PREFIX = '*STRINGIFIED*';
 
 const PLUGIN_CHARACTERISTICS_ATTRIBUTES = ['plugins', 'mimeTypes'];
 
+/**
+ * Below this share of input records passing schema validation, the input dataset is
+ * treated as broken rather than merely noisy. A model built from that little data is
+ * not worth shipping, and silently shipping one is how a degraded collector reaches
+ * npm unnoticed.
+ */
+const MIN_VALID_RECORD_RATIO = 0.25;
+
+/** Absolute floor on usable records, regardless of ratio. */
+const MIN_VALID_RECORDS = 2000;
+
 async function prepareRecords(
     records: Record<string, any>[],
     preprocessingType: string,
 ): Promise<Record<string, any>[]> {
     const recordSchema = await getRecordSchema();
 
-    const cleanedRecords = records
-        .map((x) => recordSchema.safeParse(x))
+    const parsed = records.map((x) => recordSchema.safeParse(x));
+    const cleanedRecords = parsed
         .filter((record) => record.success)
         .map((record) => record.data);
 
+    const ratio =
+        records.length === 0 ? 0 : cleanedRecords.length / records.length;
+
     console.log(
-        `Found ${cleanedRecords.length}/${records.length} valid records.`,
+        `Found ${cleanedRecords.length}/${records.length} valid records (${(
+            ratio * 100
+        ).toFixed(1)}%).`,
     );
+
+    // Attribute the rejections. Without this, a validation change or a collector
+    // regression that quietly discards most of the input is invisible in the logs.
+    const reasons = new Map<string, number>();
+    for (const record of parsed) {
+        if (record.success) continue;
+        const seen = new Set<string>();
+        for (const issue of record.error.issues) {
+            const key = `${issue.path.join('.') || '<root>'}: ${issue.message}`;
+            seen.add(key);
+        }
+        for (const key of seen) reasons.set(key, (reasons.get(key) ?? 0) + 1);
+    }
+
+    if (reasons.size > 0) {
+        console.log('Top rejection reasons:');
+        for (const [reason, count] of [...reasons.entries()]
+            .sort((a, b) => b[1] - a[1])
+            .slice(0, 15)) {
+            console.log(`  ${String(count).padStart(6)}  ${reason}`);
+        }
+    }
+
+    if (
+        cleanedRecords.length < MIN_VALID_RECORDS ||
+        ratio < MIN_VALID_RECORD_RATIO
+    ) {
+        throw new Error(
+            `Refusing to build the ${preprocessingType} model: only ${
+                cleanedRecords.length
+            }/${records.length} (${(ratio * 100).toFixed(
+                1,
+            )}%) input records are valid, below the ${MIN_VALID_RECORDS}-record / ${(
+                MIN_VALID_RECORD_RATIO * 100
+            ).toFixed(
+                0,
+            )}% floor. Either the source dataset is degraded or the record schema needs updating — see the rejection reasons above.`,
+        );
+    }
 
     const deconstructedRecords = cleanedRecords
         .map((record) => {
@@ -115,8 +170,12 @@ export class GeneratorNetworksCreator {
             /opr|yabrowser|SamsungBrowser|UCBrowser|vivaldi/i;
         const edge = /(edg(a|ios|e)?)\/([0-9.]*)/i;
         const safari = /Version\/([\d.]+)( Mobile\/[a-z0-9]+)? Safari/i;
-        const supportedBrowsers =
-            /(firefox|fxios|chrome|crios|safari)\/([0-9.]*)/i;
+        // `safari` is deliberately absent here: the `Safari/x.y.z` token carries the
+        // WebKit build number, not the Safari version. Only the `Version/x.y` token
+        // (handled by `safari` above) does. Matching `Safari/...` as a fallback would
+        // mint bogus browsers like `safari/605.1` that no browserslist query can ever
+        // select, silently corrupting the model.
+        const supportedBrowsers = /(firefox|fxios|chrome|crios)\/([0-9.]*)/i;
 
         if (unsupportedBrowsers.test(userAgent)) {
             return missingValueDatasetToken;

--- a/packages/generator-networks-creator/src/record-schema.ts
+++ b/packages/generator-networks-creator/src/record-schema.ts
@@ -175,7 +175,12 @@ export async function getRecordSchema() {
                         .object({
                             charging: z.boolean(),
                             chargingTime: z.number().nullable(),
-                            dischargingTime: z.boolean().nullable(),
+                            // Seconds of battery life remaining, per the Battery Status
+                            // API — not a boolean. Declaring this `z.boolean()` rejected
+                            // every record from a device actually running on battery
+                            // (~24% of the dataset), biasing the model towards charging
+                            // and battery-less machines.
+                            dischargingTime: z.number().nullable(),
                             level: z.number().min(0).max(1),
                         })
                         .nullable(),

--- a/scripts/verify-model.ts
+++ b/scripts/verify-model.ts
@@ -1,0 +1,389 @@
+/* eslint-disable no-console */
+/**
+ * Post-build sanity gate for the generated fingerprint/header model.
+ *
+ * Runs after `netgen.ts` (and the rebuild that follows it) and refuses to let a
+ * degraded model progress any further. This exists because of
+ * https://github.com/apify/fingerprint-suite/issues/564: the automated update
+ * shipped a model whose newest Chrome was 143 while the world was on 150, so
+ * `browserListQuery: 'last 5 chrome versions'` matched nothing and threw. The
+ * existing test suite passed, because nothing asserted the model actually covers
+ * current browsers.
+ *
+ * Checks, in order of how directly they map to user-visible breakage:
+ *   1. functional  — the browserslist queries users actually write still resolve
+ *   2. freshness   — the model is not lagging far behind current browser releases
+ *   3. regression  — no browser's newest version went backwards vs the committed model
+ *   4. plausibility — no bogus browsers/versions (e.g. `safari/605.1`, a WebKit build)
+ *   5. volume      — the model did not lose a large share of its browser coverage
+ *
+ * Exits non-zero listing every failure, so one run reports the full picture.
+ */
+import { execFileSync } from 'node:child_process';
+import fs from 'node:fs';
+import path from 'node:path';
+
+import browserslist from 'browserslist';
+
+// Imported by relative path rather than package name so this script needs no
+// entry in the root manifest, and so it exercises the same sources the packages
+// publish.
+import { FingerprintGenerator } from '../packages/fingerprint-generator/src';
+import { HeaderGenerator } from '../packages/header-generator/src';
+
+const REPO_ROOT = path.join(__dirname, '..');
+const HELPER_FILE_REL =
+    'packages/header-generator/src/data_files/browser-helper-file.json';
+
+/** Browsers the model is expected to cover, and the plausible range for a major version. */
+const EXPECTED_BROWSERS = {
+    chrome: { minMajor: 60, maxMajor: 300, freshnessTolerance: 3 },
+    firefox: { minMajor: 60, maxMajor: 300, freshnessTolerance: 3 },
+    edge: { minMajor: 60, maxMajor: 300, freshnessTolerance: 3 },
+    // Safari jumped 18 -> 26 when Apple moved to year-based versioning, so the
+    // upper bound is generous. It must stay well below WebKit build numbers
+    // (604.x / 605.x), which is exactly the corruption seen in #564.
+    safari: { minMajor: 11, maxMajor: 100, freshnessTolerance: 2 },
+} as const;
+
+type BrowserName = keyof typeof EXPECTED_BROWSERS;
+
+/** A model that covers fewer than this fraction of the previous one is suspect. */
+const MIN_COMBO_RETENTION = 0.6;
+
+const failures: string[] = [];
+const warnings: string[] = [];
+
+function fail(check: string, message: string) {
+    failures.push(`[${check}] ${message}`);
+}
+
+function warn(check: string, message: string) {
+    warnings.push(`[${check}] ${message}`);
+}
+
+/** `['chrome/150.0.0.0|2', ...]` -> `{ chrome: [150, 149, ...] }` (majors, desc). */
+function parseHelperFile(entries: string[]): {
+    majorsByBrowser: Map<string, number[]>;
+    unparsed: string[];
+} {
+    const majorsByBrowser = new Map<string, number[]>();
+    const unparsed: string[] = [];
+
+    for (const entry of entries) {
+        const [browserVersion] = entry.split('|');
+        const separator = browserVersion.lastIndexOf('/');
+
+        if (separator === -1) {
+            unparsed.push(entry);
+            continue;
+        }
+
+        const name = browserVersion.slice(0, separator);
+        const major = Number.parseInt(browserVersion.slice(separator + 1), 10);
+
+        if (!Number.isFinite(major)) {
+            unparsed.push(entry);
+            continue;
+        }
+
+        const majors = majorsByBrowser.get(name) ?? [];
+        majors.push(major);
+        majorsByBrowser.set(name, majors);
+    }
+
+    for (const majors of majorsByBrowser.values()) {
+        majors.sort((a, b) => b - a);
+    }
+
+    return { majorsByBrowser, unparsed };
+}
+
+/** The newest major version browserslist knows about for a browser, if any. */
+function newestKnownMajor(browser: BrowserName): number | null {
+    try {
+        const [newest] = browserslist(`last 1 ${browser} version`);
+        if (!newest) return null;
+        const major = Number.parseInt(newest.split(' ')[1], 10);
+        return Number.isFinite(major) ? major : null;
+    } catch {
+        return null;
+    }
+}
+
+/** The committed model's helper file, i.e. what we are about to replace. */
+function previousHelperEntries(): string[] | null {
+    try {
+        const raw = execFileSync('git', ['show', `HEAD:${HELPER_FILE_REL}`], {
+            cwd: REPO_ROOT,
+            encoding: 'utf8',
+            stdio: ['ignore', 'pipe', 'ignore'],
+        });
+        return JSON.parse(raw) as string[];
+    } catch {
+        return null;
+    }
+}
+
+// ---------------------------------------------------------------------------
+// 1. Functional: the queries users actually write must resolve.
+// ---------------------------------------------------------------------------
+function checkQueriesResolve() {
+    const queries = [
+        ...Object.keys(EXPECTED_BROWSERS).map(
+            (browser) => `last 5 ${browser} versions`,
+        ),
+        'last 2 versions',
+        'last 10 chrome versions',
+        '> 0.5%',
+    ];
+
+    for (const browserListQuery of queries) {
+        try {
+            const headers = new HeaderGenerator({
+                browserListQuery,
+            }).getHeaders();
+
+            if (!headers['user-agent'] && !headers['User-Agent']) {
+                fail(
+                    'functional',
+                    `query '${browserListQuery}' produced headers without a User-Agent.`,
+                );
+            }
+        } catch (error) {
+            fail(
+                'functional',
+                `query '${browserListQuery}' cannot generate headers — this is the #564 failure mode. ${
+                    (error as Error).message
+                }`,
+            );
+        }
+    }
+
+    // Per-browser generation, independent of browserslist data.
+    for (const browser of Object.keys(EXPECTED_BROWSERS)) {
+        try {
+            new HeaderGenerator({
+                browsers: [browser as BrowserName],
+            }).getHeaders();
+        } catch (error) {
+            fail(
+                'functional',
+                `cannot generate headers for browser '${browser}'. ${
+                    (error as Error).message
+                }`,
+            );
+        }
+    }
+
+    try {
+        const { fingerprint } = new FingerprintGenerator().getFingerprint();
+        if (!fingerprint?.navigator?.userAgent) {
+            fail(
+                'functional',
+                'generated fingerprint has no navigator.userAgent.',
+            );
+        }
+        if (
+            !(fingerprint?.screen?.width > 0 && fingerprint?.screen?.height > 0)
+        ) {
+            fail(
+                'functional',
+                'generated fingerprint has non-positive screen dimensions.',
+            );
+        }
+    } catch (error) {
+        fail(
+            'functional',
+            `fingerprint generation failed outright. ${(error as Error).message}`,
+        );
+    }
+}
+
+/**
+ * Writes a human-readable before/after summary for the model-update pull request,
+ * so a reviewer can see at a glance what the new model actually covers.
+ */
+function writeSummary(
+    entries: string[],
+    current: Map<string, number[]>,
+    previousEntries: string[] | null,
+    previous: Map<string, number[]> | null,
+) {
+    const lines = [
+        '### Model coverage',
+        '',
+        '| browser | newest (before) | newest (after) | versions |',
+        '| --- | --- | --- | --- |',
+    ];
+
+    for (const browser of Object.keys(EXPECTED_BROWSERS).sort()) {
+        const majors = current.get(browser);
+        const before = previous?.get(browser)?.[0];
+        lines.push(
+            `| ${browser} | ${before ?? '—'} | ${majors?.[0] ?? '**missing**'} | ${
+                majors?.length ?? 0
+            } |`,
+        );
+    }
+
+    lines.push(
+        '',
+        `Browser/HTTP-version combinations: ${
+            previousEntries ? `${previousEntries.length} → ` : ''
+        }${entries.length}`,
+    );
+
+    if (warnings.length > 0) {
+        lines.push('', '### Warnings', '');
+        for (const warning of warnings) lines.push(`- ${warning}`);
+    }
+
+    fs.writeFileSync(
+        path.join(REPO_ROOT, 'model-summary.md'),
+        `${lines.join('\n')}\n`,
+    );
+}
+
+// ---------------------------------------------------------------------------
+// 2-5. Data-shape checks over the helper file.
+// ---------------------------------------------------------------------------
+function checkHelperFile() {
+    const helperPath = path.join(REPO_ROOT, HELPER_FILE_REL);
+    const entries = JSON.parse(
+        fs.readFileSync(helperPath, { encoding: 'utf8' }),
+    ) as string[];
+
+    const { majorsByBrowser, unparsed } = parseHelperFile(entries);
+
+    console.log(
+        `Model covers ${entries.length} browser/HTTP-version combinations:`,
+    );
+    for (const [browser, majors] of [...majorsByBrowser].sort()) {
+        console.log(
+            `  ${browser.padEnd(10)} newest ${String(majors[0]).padEnd(
+                5,
+            )} (${majors.length} versions)`,
+        );
+    }
+
+    if (unparsed.length > 0) {
+        fail(
+            'plausibility',
+            `${unparsed.length} helper-file entries are not parseable as browser/version: ${unparsed
+                .slice(0, 5)
+                .join(', ')}`,
+        );
+    }
+
+    for (const [browser, config] of Object.entries(EXPECTED_BROWSERS) as [
+        BrowserName,
+        (typeof EXPECTED_BROWSERS)[BrowserName],
+    ][]) {
+        const majors = majorsByBrowser.get(browser);
+
+        if (!majors || majors.length === 0) {
+            fail(
+                'plausibility',
+                `model contains no '${browser}' entries at all.`,
+            );
+            continue;
+        }
+
+        // 4. Plausibility — catches `safari/605.1` (a WebKit build number).
+        const newest = majors[0];
+        const oldest = majors[majors.length - 1];
+
+        if (newest > config.maxMajor) {
+            fail(
+                'plausibility',
+                `newest '${browser}' version is ${newest}, above the plausible maximum of ${config.maxMajor}. ` +
+                    `This usually means a build/engine number was parsed as a browser version.`,
+            );
+        }
+        if (oldest < config.minMajor) {
+            warn(
+                'plausibility',
+                `oldest '${browser}' version is ${oldest}, below the expected minimum of ${config.minMajor}.`,
+            );
+        }
+
+        // 2. Freshness — the #564 symptom.
+        const known = newestKnownMajor(browser);
+        if (known === null) {
+            warn(
+                'freshness',
+                `browserslist knows no versions for '${browser}'; skipped.`,
+            );
+        } else if (newest < known - config.freshnessTolerance) {
+            fail(
+                'freshness',
+                `newest '${browser}' in the model is ${newest}, but browserslist's newest is ${known} ` +
+                    `(tolerance ${config.freshnessTolerance}). Queries selecting recent ${browser} versions will match nothing.`,
+            );
+        }
+    }
+
+    // 3. Regression + 5. Volume, against the model we are replacing.
+    const previous = previousHelperEntries();
+    if (previous === null) {
+        warn(
+            'regression',
+            `could not read the committed ${HELPER_FILE_REL} from git; skipped comparison against the previous model.`,
+        );
+        writeSummary(entries, majorsByBrowser, null, null);
+        return;
+    }
+
+    const { majorsByBrowser: previousMajors } = parseHelperFile(previous);
+    writeSummary(entries, majorsByBrowser, previous, previousMajors);
+
+    for (const [browser, majors] of previousMajors) {
+        const current = majorsByBrowser.get(browser);
+        if (!current || current.length === 0) continue;
+
+        if (current[0] < majors[0]) {
+            fail(
+                'regression',
+                `newest '${browser}' went backwards: ${majors[0]} in the committed model, ${current[0]} in the new one. ` +
+                    `A newer model should never cover older browsers.`,
+            );
+        }
+    }
+
+    if (previous.length > 0) {
+        const retention = entries.length / previous.length;
+        if (retention < MIN_COMBO_RETENTION) {
+            fail(
+                'volume',
+                `model covers ${entries.length} browser/HTTP combinations, down from ${
+                    previous.length
+                } (${(retention * 100).toFixed(
+                    0,
+                )}% retained, floor ${(MIN_COMBO_RETENTION * 100).toFixed(0)}%).`,
+            );
+        }
+    }
+}
+
+checkQueriesResolve();
+checkHelperFile();
+
+if (warnings.length > 0) {
+    console.warn(`\n${warnings.length} warning(s):`);
+    for (const warning of warnings) console.warn(`  ! ${warning}`);
+}
+
+if (failures.length > 0) {
+    console.error(
+        `\nModel verification FAILED with ${failures.length} problem(s):`,
+    );
+    for (const failure of failures) console.error(`  x ${failure}`);
+    console.error(
+        '\nThe generated model is not fit to ship. Inspect the source dataset and the ' +
+            'record schema before overriding this gate.',
+    );
+    process.exit(1);
+}
+
+console.log('\nModel verification passed.');

--- a/test/generator-networks-creator/generator-networks-creator.test.ts
+++ b/test/generator-networks-creator/generator-networks-creator.test.ts
@@ -139,6 +139,24 @@ describe('Processing browser data', () => {
             expectedOS: 'windows',
             expectedDeviceType: 'desktop',
         },
+        // Safari without a `Version/` token: the `Safari/x.y.z` number is the WebKit
+        // build, not the browser version. Reading it as a version produced the bogus
+        // `safari/605.1` entries that corrupted the model in #564, so these must be
+        // rejected outright rather than guessed at.
+        {
+            userAgent:
+                'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/605.1.15 (KHTML, like Gecko) Safari/605.1.15',
+            expectedBrowser: '*MISSING_VALUE*',
+            expectedOS: 'macos',
+            expectedDeviceType: 'desktop',
+        },
+        {
+            userAgent:
+                'Mozilla/5.0 (iPhone; CPU iPhone OS 18_0 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Mobile/15E148 Safari/604.1',
+            expectedBrowser: '*MISSING_VALUE*',
+            expectedOS: 'ios',
+            expectedDeviceType: 'mobile',
+        },
     ];
 
     test('Extracts browser name/version from User-Agent', () => {

--- a/test/header-generator/model-sanity.test.ts
+++ b/test/header-generator/model-sanity.test.ts
@@ -1,0 +1,84 @@
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
+
+import { HeaderGenerator } from 'header-generator';
+
+import { describe, expect, test } from 'vitest';
+
+/**
+ * Guards the *committed* model against the class of breakage reported in
+ * https://github.com/apify/fingerprint-suite/issues/564, where an automated model
+ * update shipped a model covering only stale browser versions. Every existing test
+ * passed, because none of them asserted that the model can still satisfy the
+ * browserslist queries users actually write.
+ *
+ * `scripts/verify-model.ts` runs the equivalent checks at model-build time; these
+ * tests keep the invariant enforced for every change to the repository.
+ */
+describe('committed model sanity', () => {
+    const helperFile = JSON.parse(
+        readFileSync(
+            join(
+                __dirname,
+                '../../packages/header-generator/src/data_files/browser-helper-file.json',
+            ),
+            { encoding: 'utf8' },
+        ),
+    ) as string[];
+
+    const browsers = ['chrome', 'firefox', 'safari', 'edge'] as const;
+
+    test.each(browsers)(
+        "generates headers for 'last 5 %s versions'",
+        (browser) => {
+            const generator = new HeaderGenerator({
+                browserListQuery: `last 5 ${browser} versions`,
+            });
+
+            // A throw here means the model's newest versions no longer overlap the
+            // last 5 releases browserslist knows about: either the model is stale
+            // (regenerate it) or caniuse-lite has moved well ahead of it.
+            expect(() => generator.getHeaders()).not.toThrow();
+        },
+    );
+
+    test.each(browsers)('generates headers for browser %s', (browser) => {
+        expect(() =>
+            new HeaderGenerator({ browsers: [browser] }).getHeaders(),
+        ).not.toThrow();
+    });
+
+    test("generates headers for 'last 2 versions'", () => {
+        expect(() =>
+            new HeaderGenerator({
+                browserListQuery: 'last 2 versions',
+            }).getHeaders(),
+        ).not.toThrow();
+    });
+
+    test('covers every supported browser', () => {
+        for (const browser of browsers) {
+            expect(
+                helperFile.some((entry) => entry.startsWith(`${browser}/`)),
+            ).toBe(true);
+        }
+    });
+
+    test('contains no engine build numbers masquerading as browser versions', () => {
+        // `Safari/605.1.15` is a WebKit build, not a Safari version. Entries like
+        // `safari/605.1` mean the User-Agent parser fell through to the wrong token.
+        const implausible = helperFile.filter((entry) => {
+            const [browserVersion] = entry.split('|');
+            const separator = browserVersion.lastIndexOf('/');
+            if (separator === -1) return true;
+
+            const major = Number.parseInt(
+                browserVersion.slice(separator + 1),
+                10,
+            );
+            return !Number.isFinite(major) || major > 300;
+        });
+
+        expect(implausible).toEqual([]);
+    });
+});


### PR DESCRIPTION
Follow-up to #564. **Stacked on #565** — base is `fix/revert-regressed-model-data`, so this diff shows only the hardening. GitHub will retarget it to `master` once #565 merges.

## What actually went wrong

I rebuilt the model locally from the source dataset (`DsGkByS7EobGevEH1`, newest 30 000 records). It produces a **healthy** model — newest Chrome 153, Safari 27, no bogus entries. So the pipeline code was never broken: the Aug 1 run consumed bad input and shipped it unattended.

The raw dataset today is dominated by Chrome 150/151, and those records pass validation. The published v2.1.87 model topped out at Chrome 143, while browserslist resolves `last 5 chrome versions` to 146–150 — zero overlap, hence the throw.

The pipeline could not have noticed, for three independent reasons:

1. `prepareRecords` dropped every invalid record **silently** — one `Found X/Y valid records` line, no breakdown, no floor.
2. **Nothing asserted the model covers current browsers.** `test_model_js` passed on the bad model, because generation with default options works fine when the model is merely stale.
3. The updater **pushed, tagged and released in one step**, and creating the release is what triggers the npm/PyPI publish. No human in the loop.

## Two genuine bugs found while reproducing

**1. WebKit build number read as a Safari version** (`generator-networks-creator.ts`)

`getBrowserNameVersion` fell back to matching the `Safari/x.y.z` token. That token is the WebKit build; only `Version/x.y` carries the Safari version. So a Safari UA without `Version/` became:

```
'…AppleWebKit/605.1.15 (KHTML, like Gecko) Safari/605.1.15'  ->  safari/605.1.15
'…Mobile/15E148 Safari/604.1'                                 ->  safari/604.1
```

This is exactly the `safari/605.1` visible in v2.1.87's helper file. Such entries can never match any browserslist query, and real Safari records get mislabelled. Fixed by removing `safari` from the fallback pattern, so these are rejected outright rather than guessed at. Test cases added.

**2. `battery.dischargingTime` typed as boolean** (`record-schema.ts`)

The schema declared `dischargingTime: z.boolean().nullable()`. It is **seconds remaining** per the Battery Status API:

```json
{ "charging": false, "chargingTime": null, "dischargingTime": 16140, "level": 0.93 }
```

This rejected **7 266 of 30 000 records — 24% of the dataset**. Worse than volume loss, it was *systematic*: only devices that were charging or had no battery survived, biasing the model against laptops on battery. Fixing it raises the validation pass rate **56.7% → 78.5%** and lifts coverage from 137 to 152 browser/HTTP combinations.

I left the `screen.*` rejection rules alone — negative `screenX` on multi-monitor setups is arguably legitimate input, but that is a separate judgement call and #541/`8f03ef5` is already in that area.

## The hardening

**`scripts/verify-model.ts`** — post-build gate, run by `pnpm buildNetwork`. Five check families, ordered by how directly they map to user-visible breakage:

| check | catches |
| --- | --- |
| functional | the browserslist queries users actually write no longer resolve |
| freshness | model lagging current browser releases beyond a tolerance |
| regression | a browser's newest version went **backwards** vs the committed model |
| plausibility | bogus versions such as `safari/605.1` |
| volume | coverage collapsed vs the previous model |

Verified against the real v2.1.87 model — **10 failures across 4 families**:

```
x [functional]    query 'last 5 firefox versions' cannot generate headers …
x [functional]    fingerprint generation failed outright …
x [freshness]     newest 'chrome' in the model is 143, but browserslist's newest is 147 …
x [plausibility]  newest 'safari' version is 605, above the plausible maximum of 100 …
x [regression]    newest 'chrome' went backwards: 149 in the committed model, 143 in the new one …
```

Worth noting: `last 5 chrome versions` did **not** fail in that run, because this repo's `caniuse-lite` thinks newest Chrome is 147, so the last-5 window still included 143. The freshness and regression checks caught it anyway. That is why there are five overlapping families rather than just the functional one — and why the workflow now refreshes `caniuse-lite` before verifying.

**Loud record rejection** — `prepareRecords` now prints the top 15 rejection reasons with counts, and refuses to build below a 2 000-record / 25% validity floor. This is how bug 2 above surfaced at all.

**`test/header-generator/model-sanity.test.ts`** — keeps the same invariants enforced for the *committed* model on every PR, not just at model-build time. Verified: 3 failures on the v2.1.87 model, 11 passing on a good one.

**PR-based updates** (your suggestion, and the right structural fix):

- `model-updater.yml` now commits to `model-update/v<version>` and opens a PR. It no longer pushes to master, tags, or releases.
- `model-release.yml` (new) tags and creates the release on `pull_request: closed` when a merged branch matches `model-update/*`. Since `publish-to-npm.yaml` triggers on `release: published`, **the npm and PyPI publish is now gated on a human merging.**
- The PR body carries a generated coverage table (before → after newest version per browser), so a reviewer can eyeball exactly what changed.
- Being a real PR, it also picks up the standard `test-and-sync.yml` checks.

**Housekeeping** — `scripts/dataset.json` (~215 MB, rewritten by `netgen.sh` on every run) was untracked *and* un-ignored, one `git add -A` away from being committed. Now gitignored.

## Verification

- Built the model end-to-end locally from the real dataset with all fixes: 78.5% validity, gate passes, coverage 152 combos (Chrome 153 / Edge 152 / Firefox 153 / Safari 27).
- Gate correctly rejects the v2.1.87 model, correctly accepts a good one.
- `vitest run test/header-generator test/generator-networks-creator test/fingerprint-generator test/generative-bayesian-network`: **59 passed, 1 skipped**.
- Both workflow files parse as valid YAML; jobs resolve as expected.
- `fingerprint-injector` browser tests still fail in my sandbox (httpbin unreachable, Firefox-under-Puppeteer) — pre-existing and unrelated, same failures on unmodified `master`.
- Lint: one pre-existing `import/no-extraneous-dependencies` error in `test/antibot-services/live-testing/speed.js`, untouched by this PR.

## Deliberately not included

No regenerated model blobs. My local build cannot produce `headers-order.json`, which needs the xvfb browser-collection step from CI, so a locally built model set would be internally inconsistent. Once this and #565 land, a `workflow_dispatch` run of the updater will open a model PR with the improved data for review.

## Things to check before merging

- `pnpm dlx update-browserslist-db@latest` in the build job mutates `pnpm-lock.yaml`. The workflow already committed the lockfile, so this fits, but drop the step if you would rather keep lockfile changes out of model updates — the freshness check degrades gracefully without it.
- The `model-update/*` branch-name prefix is the contract between the two workflows. Renaming it in one place breaks releases silently.
- `model-release.yml` reads the version from `master`'s `package.json` after merge. That is correct for squash and merge-commit alike, but assumes no other version bump lands between PR creation and merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
