### PR TITLE
chore: release v2.1.88 (hotfix for #564)

### DIFF
--- a/apify_fingerprint_datapoints/CHANGELOG.md
+++ b/apify_fingerprint_datapoints/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 All notable changes to this project will be documented in this file.
 
+## 0.15.0 - (2026-08-05)
+
+- Reverted the data shipped in `0.14.0` back to the previous model: it only covered
+  stale browser versions and broke `browserListQuery`-based header generation. Same
+  as npm package `fingerprint-generator` version `2.1.88`. See
+  https://github.com/apify/fingerprint-suite/issues/564.
+
 ## 0.14.0 - (2026-08-01)
 
 - Updated data. Same as npm package `fingerprint-generator` version `2.1.87`

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
     "name": "fingerprint-suite",
     "private": true,
-    "version": "2.1.87",
+    "version": "2.1.88",
     "description": "",
     "keywords": [
         "apify",

--- a/packages/fingerprint-generator/package.json
+++ b/packages/fingerprint-generator/package.json
@@ -1,6 +1,6 @@
 {
     "name": "fingerprint-generator",
-    "version": "2.1.87",
+    "version": "2.1.88",
     "description": "NodeJS package for generating realistic browser fingerprints.",
     "homepage": "https://github.com/apify/fingerprint-suite",
     "engines": {

--- a/packages/fingerprint-injector/package.json
+++ b/packages/fingerprint-injector/package.json
@@ -1,6 +1,6 @@
 {
     "name": "fingerprint-injector",
-    "version": "2.1.87",
+    "version": "2.1.88",
     "description": "Browser fingerprint injection library for Playwright and Puppeteer.",
     "homepage": "https://github.com/apify/fingerprint-suite",
     "engines": {

--- a/packages/generative-bayesian-network/package.json
+++ b/packages/generative-bayesian-network/package.json
@@ -1,6 +1,6 @@
 {
     "name": "generative-bayesian-network",
-    "version": "2.1.87",
+    "version": "2.1.88",
     "author": {
         "name": "Apify"
     },

--- a/packages/generator-networks-creator/package.json
+++ b/packages/generator-networks-creator/package.json
@@ -1,6 +1,6 @@
 {
     "name": "generator-networks-creator",
-    "version": "2.1.87",
+    "version": "2.1.88",
     "engines": {
         "node": ">=16.0.0"
     },

--- a/packages/header-generator/package.json
+++ b/packages/header-generator/package.json
@@ -1,6 +1,6 @@
 {
     "name": "header-generator",
-    "version": "2.1.87",
+    "version": "2.1.88",
     "description": "NodeJS package for generating realistic browser-like HTTP headers.",
     "author": {
         "name": "Apify",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "apify_fingerprint_datapoints"
-version = "0.14.0"
+version = "0.15.0"
 description = "Browser fingerprint datapoints collected by Apify"
 authors = [{ name = "Apify Technologies s.r.o.", email = "support@apify.com" }]
 license = { file = "LICENSE.md" }


### PR DESCRIPTION
Bumps package versions to release the reverted model updates.