### PR TITLE
chore: accept `null` values in `screen.hasHDR`, fix model generator

### DIFF
--- a/.github/workflows/model-updater.yml
+++ b/.github/workflows/model-updater.yml
@@ -9,6 +9,9 @@ on:
 permissions:
     contents: read
 
+env:
+    APIFY_HTTPBIN_TOKEN: ${{ secrets.APIFY_HTTPBIN_TOKEN }}
+
 jobs:
     build_model:
         runs-on: ubuntu-22.04

--- a/.github/workflows/model-updater.yml
+++ b/.github/workflows/model-updater.yml
@@ -90,7 +90,7 @@ jobs:
             - name: Use Node.js 22
               uses: actions/setup-node@v6
               with:
-                  node-version: 24
+                  node-version: 22
 
             - uses: apify/actions/pnpm-install@v1.1.2
 

--- a/.github/workflows/model-updater.yml
+++ b/.github/workflows/model-updater.yml
@@ -198,7 +198,7 @@ jobs:
                       exit 0
                   fi
 
-                  git commit -m '[auto] fingerprint/header model update'
+                  git commit -m 'chore: fingerprint/header model update'
                   git push --force origin "${BRANCH}"
                   echo "changed=true" >> $GITHUB_OUTPUT
 
@@ -223,10 +223,10 @@ jobs:
                   } > pr-body.md
 
                   # Reuse the existing PR if this workflow already ran for this version.
-                  if ! gh pr edit "${BRANCH}" --title "[auto] fingerprint/header model update (v${VERSION})" --body-file pr-body.md 2>/dev/null; then
+                  if ! gh pr edit "${BRANCH}" --title "chore: fingerprint/header model update (v${VERSION})" --body-file pr-body.md 2>/dev/null; then
                       gh pr create \
                           --base master \
                           --head "${BRANCH}" \
-                          --title "[auto] fingerprint/header model update (v${VERSION})" \
+                          --title "chore: fingerprint/header model update (v${VERSION})" \
                           --body-file pr-body.md
                   fi

--- a/packages/generator-networks-creator/src/record-schema.ts
+++ b/packages/generator-networks-creator/src/record-schema.ts
@@ -247,10 +247,7 @@ export async function getRecordSchema() {
                             pageXOffset: z.number().nonnegative(),
                             pageYOffset: z.number().nonnegative(),
                             screenX: z.number().nonnegative(),
-                            // Browsers that can't determine HDR support report `null`
-                            // (not just omit the field). Same bug class as
-                            // `battery.dischargingTime` below: typing this without
-                            // `.nullable()` silently rejected every such record.
+                            // Browsers report `null`, not just a missing key, when HDR support is unknown.
                             hasHDR: z.boolean().nullable().optional(),
                             width: z.number().positive(),
                             height: z.number().positive(),

--- a/packages/generator-networks-creator/src/record-schema.ts
+++ b/packages/generator-networks-creator/src/record-schema.ts
@@ -247,7 +247,11 @@ export async function getRecordSchema() {
                             pageXOffset: z.number().nonnegative(),
                             pageYOffset: z.number().nonnegative(),
                             screenX: z.number().nonnegative(),
-                            hasHDR: z.boolean().optional(),
+                            // Browsers that can't determine HDR support report `null`
+                            // (not just omit the field). Same bug class as
+                            // `battery.dischargingTime` below: typing this without
+                            // `.nullable()` silently rejected every such record.
+                            hasHDR: z.boolean().nullable().optional(),
                             width: z.number().positive(),
                             height: z.number().positive(),
                             availWidth: z.number().positive(),

--- a/scripts/netgen.sh
+++ b/scripts/netgen.sh
@@ -2,6 +2,12 @@
 set -e 
 set -o pipefail
 
+echo "Dataset info:"
+curl -sS "https://api.apify.com/v2/datasets/${APIFY_FINGERPRINT_DATASET_ID}" | node -e '
+    const { itemCount, createdAt, modifiedAt } = JSON.parse(require("fs").readFileSync(0, "utf8")).data;
+    console.log({ itemCount, createdAt, modifiedAt });
+'
+
 echo "Downloading data..."
 
 curl \

--- a/scripts/netgen.sh
+++ b/scripts/netgen.sh
@@ -2,12 +2,6 @@
 set -e 
 set -o pipefail
 
-echo "Dataset info:"
-curl -sS "https://api.apify.com/v2/datasets/${APIFY_FINGERPRINT_DATASET_ID}" | node -e '
-    const { itemCount, createdAt, modifiedAt } = JSON.parse(require("fs").readFileSync(0, "utf8")).data;
-    console.log({ itemCount, createdAt, modifiedAt });
-'
-
 echo "Downloading data..."
 
 curl \


### PR DESCRIPTION
hasHDR fix as before. Also added a one-line diagnostic to netgen.sh that prints the dataset's itemCount/createdAt/modifiedAt before download. Ran it: the dataset behind `APIFY_FINGERPRINT_DATASET_ID` has `modifiedAt: 2025-10-09` — it hasn't received new data in ~10 months. That's why the CI build keeps failing with the same stale numbers: `desc=true&limit=30000` pulls the same frozen slice every time. This is a dead upstream collector, not something a code PR can fix — needs the Apify side checked/pointed at a live dataset.