### PR TITLE
fix: normalize viewport fingerprint dimensions

### DIFF
--- a/packages/fingerprint-generator/src/fingerprint-generator.ts
+++ b/packages/fingerprint-generator/src/fingerprint-generator.ts
@@ -99,6 +99,29 @@ export type BrowserFingerprintWithHeaders = {
     headers: Headers;
     fingerprint: Fingerprint;
 };
+
+const normalizeScreenFingerprint = (
+    screen: ScreenFingerprint,
+): ScreenFingerprint => {
+    const innerWidth =
+        screen.innerWidth > 0
+            ? screen.innerWidth
+            : Math.min(screen.width, screen.outerWidth);
+    const innerHeight =
+        screen.innerHeight > 0
+            ? screen.innerHeight
+            : Math.min(screen.availHeight, screen.outerHeight);
+
+    return {
+        ...screen,
+        innerWidth,
+        innerHeight,
+        clientWidth: screen.clientWidth > 0 ? screen.clientWidth : innerWidth,
+        clientHeight:
+            screen.clientHeight > 0 ? screen.clientHeight : innerHeight,
+    };
+};
+
 export interface FingerprintGeneratorOptions extends HeaderGeneratorOptions {
     /**
      * Defines the screen dimensions of the generated fingerprint.
@@ -315,6 +338,7 @@ export class FingerprintGenerator extends HeaderGenerator {
         } = fingerprint;
         const parsedMemory = parseInt(deviceMemory, 10);
         const parsedTouchPoints = parseInt(maxTouchPoints, 10);
+        const normalizedScreen = normalizeScreenFingerprint(screen);
 
         const navigator = {
             userAgent,
@@ -341,7 +365,7 @@ export class FingerprintGenerator extends HeaderGenerator {
         };
 
         return {
-            screen,
+            screen: normalizedScreen,
             navigator,
             audioCodecs,
             videoCodecs,

--- a/packages/fingerprint-generator/src/fingerprint-generator.ts
+++ b/packages/fingerprint-generator/src/fingerprint-generator.ts
@@ -110,7 +110,7 @@ const normalizeScreenFingerprint = (
     const innerHeight =
         screen.innerHeight > 0
             ? screen.innerHeight
-            : Math.min(screen.availHeight, screen.outerHeight);
+            : Math.min(screen.height, screen.outerHeight);
 
     return {
         ...screen,

--- a/test/fingerprint-generator/generation.test.ts
+++ b/test/fingerprint-generator/generation.test.ts
@@ -84,6 +84,89 @@ describe('Generation tests', () => {
             expect(field).toBeDefined();
         }
     });
+
+    test('Normalizes zero viewport dimensions', () => {
+        const transformed = (fingerprintGenerator as any).transformFingerprint({
+            screen: {
+                availHeight: 875,
+                availWidth: 1440,
+                availTop: 25,
+                availLeft: 0,
+                colorDepth: 24,
+                height: 900,
+                pixelDepth: 24,
+                width: 1440,
+                devicePixelRatio: 2,
+                pageXOffset: 0,
+                pageYOffset: 0,
+                innerHeight: 0,
+                outerHeight: 858,
+                outerWidth: 1284,
+                innerWidth: 0,
+                screenX: 0,
+                clientWidth: 0,
+                clientHeight: 0,
+                hasHDR: false,
+            },
+            navigator: {
+                userAgent:
+                    'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/100.0.4896.127 Safari/537.36',
+                userAgentData: {
+                    brands: [],
+                    mobile: false,
+                    platform: 'MacOS',
+                    architecture: '',
+                    bitness: '',
+                    fullVersionList: [],
+                    model: '',
+                    platformVersion: '',
+                    uaFullVersion: '',
+                },
+                doNotTrack: '1',
+                appCodeName: 'Mozilla',
+                appName: 'Netscape',
+                appVersion: '5.0',
+                oscpu: '',
+                webdriver: 'false',
+                language: 'en-US',
+                languages: ['en-US'],
+                platform: 'MacIntel',
+                deviceMemory: 8,
+                hardwareConcurrency: '8',
+                product: 'Gecko',
+                productSub: '20030107',
+                vendor: 'Google Inc.',
+                vendorSub: '',
+                maxTouchPoints: '0',
+                extraProperties: {
+                    vendorFlavors: [],
+                    isBluetoothSupported: false,
+                    globalPrivacyControl: null,
+                    pdfViewerEnabled: true,
+                    installedApps: [],
+                },
+            },
+            languages: ['en-US'],
+            videoCodecs: {},
+            audioCodecs: {},
+            pluginsData: {},
+            battery: null,
+            videoCard: { vendor: '', renderer: '' },
+            multimediaDevices: [],
+            fonts: [],
+        });
+
+        expect(transformed.screen.innerWidth).toBeGreaterThan(0);
+        expect(transformed.screen.innerHeight).toBeGreaterThan(0);
+        expect(transformed.screen.clientWidth).toBeGreaterThan(0);
+        expect(transformed.screen.clientHeight).toBeGreaterThan(0);
+        expect(transformed.screen.clientWidth).toBe(
+            transformed.screen.innerWidth,
+        );
+        expect(transformed.screen.clientHeight).toBe(
+            transformed.screen.innerHeight,
+        );
+    });
 });
 
 describe('Generate fingerprints with basic constraints', () => {


### PR DESCRIPTION
Fixes #6 by normalizing zero viewport values in generated fingerprints.
This makes innerWidth, innerHeight, clientWidth, and clientHeight
non-zero before returning the fingerprint, and adds a regression test.